### PR TITLE
feat: Add option to directly send transaction from TonWallet

### DIFF
--- a/packages/walletkit/src/core/ApiClientToncenter.ts
+++ b/packages/walletkit/src/core/ApiClientToncenter.ts
@@ -66,6 +66,7 @@ export interface ApiClientConfig {
     timeout?: number;
     fetchApi?: typeof fetch;
     network?: CHAIN;
+    disableNetworkSend?: boolean;
 }
 
 export class ApiClientToncenter implements ApiClient {
@@ -75,6 +76,7 @@ export class ApiClientToncenter implements ApiClient {
     private readonly timeout: number;
     private readonly fetchApi: typeof fetch;
     private readonly network?: CHAIN;
+    private readonly disableNetworkSend?: boolean;
 
     constructor(config: ApiClientConfig = {}) {
         this.network = config.network;
@@ -88,6 +90,7 @@ export class ApiClientToncenter implements ApiClient {
         this.apiKey = config.apiKey;
         this.timeout = config.timeout ?? 30000;
         this.fetchApi = config.fetchApi ?? fetch;
+        this.disableNetworkSend = config.disableNetworkSend ?? false;
     }
 
     async nftItemsByAddress(request: NftItemsRequest): Promise<NftItemsResponse> {
@@ -138,6 +141,9 @@ export class ApiClientToncenter implements ApiClient {
     }
 
     async sendBoc(boc: string | Uint8Array): Promise<string> {
+        if (this.disableNetworkSend) {
+            return '';
+        }
         if (typeof boc !== 'string') {
             boc = Uint8ArrayToBase64(boc);
         }

--- a/packages/walletkit/src/types/wallet.ts
+++ b/packages/walletkit/src/types/wallet.ts
@@ -22,6 +22,7 @@ import { NftItems } from './toncenter/NftItems';
 import { PrepareSignDataResult } from '../utils/signData/sign';
 import { Hex } from './primitive';
 import { TonProofParsedMessage } from '../utils/tonProof';
+import { EventTransactionResponse } from './events';
 
 /**
  * TON network types
@@ -105,6 +106,8 @@ export interface WalletTonInterface {
     getTransactionPreview(data: ConnectTransactionParamContent | Promise<ConnectTransactionParamContent>): Promise<{
         preview: TransactionPreview;
     }>;
+
+    sendTransaction(request: ConnectTransactionParamContent): Promise<EventTransactionResponse>;
 
     getBalance(): Promise<string>;
 }


### PR DESCRIPTION
- Added `disableNetworkSend` option to `ApiClientConfig` to control network sending behavior.
- Introduced `sendTransaction` method in `WalletTonClass` for improved transaction processing.
- Created `createTransactionPreview` utility for transaction emulation, enhancing the transaction preview process.