### PR TITLE
Fix(dev-script): add port for android bridge to avoid conflicts with demo-wallet

### DIFF
--- a/packages/walletkit-android-bridge/package.json
+++ b/packages/walletkit-android-bridge/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 6000",
     "build": "node build.cjs",
     "build:quickjs": "vite build --config vite.config.quickjs.ts",
     "build:all": "pnpm run build && pnpm run build:quickjs",


### PR DESCRIPTION
Demo-wallet and walletkit-android-bridge are using Vite without a specified port, which is why they conflict when run together (ex. pnpm dev from root)