### PR TITLE
fix: add bg updates for balances

### DIFF
--- a/apps/demo-wallet/src/hooks/useWalletDataUpdater.ts
+++ b/apps/demo-wallet/src/hooks/useWalletDataUpdater.ts
@@ -24,20 +24,31 @@ export const useWalletDataUpdater = () => {
 
     // Update on address change
     useEffect(() => {
-        if (address) {
-            clearNfts();
-            clearJettons();
-            void Promise.allSettled([updateBalance(), loadUserJettons(), loadUserNfts()]);
-        }
+        if (!address) return;
+
+        clearNfts();
+        clearJettons();
+        void Promise.allSettled([updateBalance(), loadUserJettons(), loadUserNfts()]);
     }, [address, updateBalance, loadUserJettons, loadUserNfts, clearNfts, clearJettons]);
 
-    // Periodic refresh for NFTs only (balance and jettons are updated via WebSocket streaming)
+    // Periodic refresh for balances
+    useEffect(() => {
+        if (!address) return;
+
+        const interval = setInterval(() => {
+            void Promise.allSettled([updateBalance(), loadUserJettons()]);
+        }, 15_000);
+
+        return () => clearInterval(interval);
+    }, [address, updateBalance, loadUserJettons]);
+
+    // Periodic refresh for NFTs
     useEffect(() => {
         if (!address) return;
 
         const timeout = setInterval(() => {
             void refreshNfts();
-        }, 60_000);
+        }, 30_000);
 
         return () => clearInterval(timeout);
     }, [address, refreshNfts]);

--- a/apps/demo-wallet/src/hooks/useWalletDataUpdater.ts
+++ b/apps/demo-wallet/src/hooks/useWalletDataUpdater.ts
@@ -31,25 +31,29 @@ export const useWalletDataUpdater = () => {
         void Promise.allSettled([updateBalance(), loadUserJettons(), loadUserNfts()]);
     }, [address, updateBalance, loadUserJettons, loadUserNfts, clearNfts, clearJettons]);
 
-    // Periodic refresh for balances
+    // Periodic refresh: balances, jettons and NFTs sequentially to avoid overloading the backend
     useEffect(() => {
         if (!address) return;
 
-        const interval = setInterval(() => {
-            void Promise.allSettled([updateBalance(), loadUserJettons()]);
-        }, 15_000);
+        let cancelled = false;
+        let timeout: ReturnType<typeof setTimeout>;
+        const refreshInterval = 20_000;
 
-        return () => clearInterval(interval);
-    }, [address, updateBalance, loadUserJettons]);
+        const tick = async () => {
+            await updateBalance().catch(() => {});
+            if (cancelled) return;
+            await loadUserJettons().catch(() => {});
+            if (cancelled) return;
+            await refreshNfts().catch(() => {});
+            if (cancelled) return;
+            timeout = setTimeout(() => void tick(), refreshInterval);
+        };
 
-    // Periodic refresh for NFTs
-    useEffect(() => {
-        if (!address) return;
+        timeout = setTimeout(() => void tick(), refreshInterval);
 
-        const timeout = setInterval(() => {
-            void refreshNfts();
-        }, 30_000);
-
-        return () => clearInterval(timeout);
-    }, [address, refreshNfts]);
+        return () => {
+            cancelled = true;
+            clearTimeout(timeout);
+        };
+    }, [address, updateBalance, loadUserJettons, refreshNfts]);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wallet clears prior assets when the address changes and immediately reloads data.
  * Initial balance, token (jetton), and NFT loading now run together for faster visibility.
  * Background refresh consolidated: balance, tokens, and NFTs refresh regularly (~20s) while an address is active, improving real-time accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->