### PR TITLE
TON-1574 Update iOS bridge to support gasless

### DIFF
--- a/packages/walletkit-ios-bridge/src/main.ts
+++ b/packages/walletkit-ios-bridge/src/main.ts
@@ -199,7 +199,7 @@ window.initWalletKit = async (configuration, storage, bridgeTransport, sessionMa
             return initialized && !!walletKit;
         },
 
-        jettonsManager(): JettonsAPI {
+        jettons(): JettonsAPI {
             return walletKit.jettons;
         },
 

--- a/packages/walletkit-ios-bridge/src/main.ts
+++ b/packages/walletkit-ios-bridge/src/main.ts
@@ -41,6 +41,8 @@ import type {
     StakingProviderInterface,
     StakingAPI,
     EmbeddedRequestEvent,
+    GaslessAPI,
+    GaslessProviderInterface,
 } from '@ton/walletkit';
 import {
     CreateTonMnemonic,
@@ -74,6 +76,7 @@ import type {
     SwiftWalletKitConfiguration,
     SwiftWalletSigner,
 } from './types';
+import { TonApiGaslessProvider, type TonApiGaslessProviderConfig } from '@ton/walletkit/gasless/tonapi';
 
 declare global {
     interface Window {
@@ -609,6 +612,10 @@ window.initWalletKit = async (configuration, storage, bridgeTransport, sessionMa
             return TonStakersStakingProvider.createFromContext(walletKit.createFactoryContext(), config ?? {});
         },
 
+        createTonApiGaslessProvider(config?: TonApiGaslessProviderConfig): GaslessProviderInterface {
+            return TonApiGaslessProvider.createFromContext(walletKit.createFactoryContext(), config ?? {});
+        },
+
         swap(): SwapAPI {
             return walletKit.swap;
         },
@@ -620,6 +627,10 @@ window.initWalletKit = async (configuration, storage, bridgeTransport, sessionMa
         staking(): StakingAPI {
             return walletKit.staking;
         },
+
+        gasless(): GaslessAPI {
+            return walletKit.gasless;
+        }
     };
 };
 

--- a/packages/walletkit-ios-bridge/src/main.ts
+++ b/packages/walletkit-ios-bridge/src/main.ts
@@ -63,6 +63,8 @@ import { DeDustSwapProvider } from '@ton/walletkit/swap/dedust';
 import type { DeDustSwapProviderConfig } from '@ton/walletkit/swap/dedust';
 import { TonStakersStakingProvider } from '@ton/walletkit/staking/tonstakers';
 import type { TonStakersProviderConfig } from '@ton/walletkit/staking/tonstakers';
+import { TonApiGaslessProvider } from '@ton/walletkit/gasless/tonapi';
+import type { TonApiGaslessProviderConfig } from '@ton/walletkit/gasless/tonapi';
 
 import { SwiftStorageAdapter } from './SwiftStorageAdapter';
 import { SwiftWalletAdapter } from './SwiftWalletAdapter';
@@ -76,7 +78,6 @@ import type {
     SwiftWalletKitConfiguration,
     SwiftWalletSigner,
 } from './types';
-import { TonApiGaslessProvider, type TonApiGaslessProviderConfig } from '@ton/walletkit/gasless/tonapi';
 
 declare global {
     interface Window {
@@ -630,7 +631,7 @@ window.initWalletKit = async (configuration, storage, bridgeTransport, sessionMa
 
         gasless(): GaslessAPI {
             return walletKit.gasless;
-        }
+        },
     };
 };
 

--- a/packages/walletkit-ios-bridge/src/types.ts
+++ b/packages/walletkit-ios-bridge/src/types.ts
@@ -37,10 +37,14 @@ import type {
     StakingAPI,
     ConnectionRequestEvent,
     EmbeddedRequestEvent,
+    GaslessAPI,
+    GaslessProvider,
+    GaslessProviderInterface,
 } from '@ton/walletkit';
 import type { OmnistonSwapProviderConfig } from '@ton/walletkit/swap/omniston';
 import type { DeDustSwapProviderConfig } from '@ton/walletkit/swap/dedust';
 import type { TonStakersProviderConfig } from '@ton/walletkit/staking/tonstakers';
+import type { TonApiGaslessProviderConfig } from '@ton/walletkit/gasless/tonapi';
 
 export interface SwiftApiClient extends ApiClient {
     getNetwork: () => Network;
@@ -164,9 +168,13 @@ export interface SwiftWalletKit {
 
     createTonStakersStakingProvider(config?: TonStakersProviderConfig): StakingProviderInterface;
 
+    createTonApiGaslessProvider(config?: TonApiGaslessProviderConfig): GaslessProviderInterface;
+
     swap(): SwapAPI;
 
     streaming(): StreamingAPI;
 
     staking(): StakingAPI;
+
+    gasless(): GaslessAPI;
 }

--- a/packages/walletkit-ios-bridge/src/types.ts
+++ b/packages/walletkit-ios-bridge/src/types.ts
@@ -81,7 +81,7 @@ export type SwiftFetchManifest = (manifestUrl: string) => Promise<ManifestFetchR
 export interface SwiftWalletKit {
     isReady(): boolean;
 
-    jettonsManager(): JettonsAPI;
+    jettons(): JettonsAPI;
 
     setEventsListeners(callback: (type: string, event: unknown) => Promise<void>): void;
 

--- a/packages/walletkit-ios-bridge/src/types.ts
+++ b/packages/walletkit-ios-bridge/src/types.ts
@@ -38,7 +38,6 @@ import type {
     ConnectionRequestEvent,
     EmbeddedRequestEvent,
     GaslessAPI,
-    GaslessProvider,
     GaslessProviderInterface,
 } from '@ton/walletkit';
 import type { OmnistonSwapProviderConfig } from '@ton/walletkit/swap/omniston';

--- a/packages/walletkit/src/api/models/index.ts
+++ b/packages/walletkit/src/api/models/index.ts
@@ -100,6 +100,7 @@ export type {
 
 // Jetton models
 export type { Jetton } from './jettons/Jetton';
+export type { JettonInfo, JettonVerification } from './jettons/JettonInfo';
 export type { JettonsRequest } from './jettons/JettonsRequest';
 export type { JettonsResponse } from './jettons/JettonsResponse';
 export type { JettonsTransferRequest } from './jettons/JettonsTransferRequest';

--- a/packages/walletkit/src/api/models/jettons/JettonInfo.ts
+++ b/packages/walletkit/src/api/models/jettons/JettonInfo.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Verification status of a Jetton.
+ */
+export interface JettonVerification {
+    /**
+     * Indicates whether the jetton has been verified
+     */
+    verified: boolean;
+
+    /**
+     * Source of the verification
+     */
+    source?: 'toncenter' | 'community' | 'manual';
+
+    /**
+     * Warnings associated with the jetton
+     */
+    warnings?: string[];
+}
+
+/**
+ * Detailed information about a Jetton master contract.
+ */
+export interface JettonInfo {
+    /**
+     * The Jetton master contract address
+     */
+    address: string;
+
+    /**
+     * The token name
+     */
+    name: string;
+
+    /**
+     * The token symbol
+     */
+    symbol: string;
+
+    /**
+     * The token description
+     */
+    description: string;
+
+    /**
+     * The number of decimal places used by the token
+     * @format int
+     */
+    decimals?: number;
+
+    /**
+     * Total supply in the token's smallest units
+     * @format bigInt
+     */
+    totalSupply?: string;
+
+    /**
+     * URL of the token image
+     */
+    image?: string;
+
+    /**
+     * Inline base64-encoded image data
+     */
+    image_data?: string;
+
+    /**
+     * URI pointing to the token metadata
+     */
+    uri?: string;
+
+    /**
+     * Verification status of the jetton
+     */
+    verification?: JettonVerification;
+
+    /**
+     * Additional arbitrary metadata related to the jetton
+     */
+    metadata?: { [key: string]: unknown };
+}

--- a/packages/walletkit/src/clients/toncenter/ApiClientToncenter.ts
+++ b/packages/walletkit/src/clients/toncenter/ApiClientToncenter.ts
@@ -9,7 +9,7 @@
 import { Address } from '@ton/core';
 
 import { Base64ToBigInt, Base64Normalize, Base64ToHex } from '../../utils/base64';
-import type { JettonInfo } from '../../types';
+import type { JettonInfo } from '../../api/models';
 import type { ToncenterEmulationResponse } from './types/raw-emulation';
 import type {
     ApiClient,

--- a/packages/walletkit/src/core/JettonsManager.ts
+++ b/packages/walletkit/src/core/JettonsManager.ts
@@ -14,10 +14,10 @@ import { LRUCache } from 'lru-cache';
 import type { EmulationTokenInfoMasters } from '../types/toncenter/emulation';
 import { globalLogger } from './Logger';
 import type { WalletKitEventEmitter } from '../types/emitter';
-import type { JettonInfo, JettonsAPI } from '../types/jettons';
+import type { JettonsAPI } from '../types/jettons';
 import { JettonError, JettonErrorCode } from '../types/jettons';
 import type { NetworkManager } from './NetworkManager';
-import type { Jetton } from '../api/models';
+import type { Jetton, JettonInfo } from '../api/models';
 import type { Network } from '../api/models';
 import { asMaybeAddressFriendly } from '../utils';
 
@@ -133,7 +133,7 @@ export class JettonsManager implements JettonsAPI {
                 }
 
                 const result: JettonInfo = {
-                    address: jetton.jetton,
+                    address: jetton.address,
                     name: tokenInfo?.name ?? '',
                     symbol: tokenInfo?.symbol ?? '',
                     description: tokenInfo?.description ?? '',

--- a/packages/walletkit/src/types/index.ts
+++ b/packages/walletkit/src/types/index.ts
@@ -32,8 +32,6 @@ export { DEFAULT_DURABLE_EVENTS_CONFIG } from './durableEvents';
 
 // Jettons types
 export type {
-    JettonInfo,
-    JettonVerification,
     AddressJetton,
     JettonBalance,
     JettonTransferParams,

--- a/packages/walletkit/src/types/jettons.ts
+++ b/packages/walletkit/src/types/jettons.ts
@@ -8,28 +8,7 @@
 
 // Jettons API types based on JETTONS.md specification
 
-import type { Jetton, Network } from '../api/models';
-
-// === Core Jetton Information ===
-export interface JettonInfo {
-    address: string;
-    name: string;
-    symbol: string;
-    description: string;
-    decimals?: number;
-    totalSupply?: string;
-    image?: string;
-    image_data?: string;
-    uri?: string;
-    verification?: JettonVerification;
-    metadata?: Record<string, unknown>;
-}
-
-export interface JettonVerification {
-    verified: boolean;
-    source?: 'toncenter' | 'community' | 'manual';
-    warnings?: string[];
-}
+import type { Jetton, JettonInfo, Network } from '../api/models';
 
 // === User's Jetton Holdings ===
 export interface AddressJetton extends JettonInfo {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Extended the WalletKit iOS bridge with gasless transaction provider support.
* Added a Ton API gasless provider factory method with optional configuration.
* Exposed a `gasless` accessor on the bridge for easier gasless capability access.

## API Changes
* Renamed the jettons accessor from `jettonsManager()` to `jettons()` on the iOS bridge.

## New Models
* Added `JettonInfo` and `JettonVerification` public types for jetton metadata and verification details.

## Bug Fixes
* Updated `JettonInfo` to use the jetton’s master address field for returned/cached results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->