### PR TITLE
feat(custom-provider): add custom providers support

### DIFF
--- a/.changeset/custom-providers.md
+++ b/.changeset/custom-providers.md
@@ -1,0 +1,22 @@
+---
+"@ton/walletkit": patch
+"@ton/appkit": patch
+"@ton/appkit-react": patch
+---
+
+Add support for custom providers — third-party providers (`type: 'custom'`) that expose their own methods rather than an SDK-defined API. Register one with `registerProvider`, then retrieve it by id; pass the expected type as a generic argument to narrow the result.
+
+**@ton/walletkit**
+
+- New `CustomProvidersManager` (keyed by `providerId`) and the `CustomProvider` interface, both exported from the package root.
+- Custom providers are registered through the existing `registerProvider` flow and reachable via the `customProviders` getter on the kit.
+- `getProvider<T extends CustomProvider>(id)` returns the registered provider (or `undefined`), narrowed to `T`.
+
+**@ton/appkit**
+
+- New `getCustomProvider(appKit, { id })` action, returning the provider narrowed to the generic type argument, and `watchCustomProviders(appKit, { onChange })` to react to registrations.
+- Re-exports the `CustomProvider` type and exposes `customProvidersManager` on `AppKit`.
+
+**@ton/appkit-react**
+
+- New `useCustomProvider<T>(id)` hook — reads a custom provider by id and re-renders when custom providers are registered.

--- a/demo/examples/src/appkit/actions/providers/get-custom-provider.ts
+++ b/demo/examples/src/appkit/actions/providers/get-custom-provider.ts
@@ -15,10 +15,7 @@ interface MyCustomProvider extends CustomProvider {
 
 export const getCustomProviderExample = (appKit: AppKit) => {
     // SAMPLE_START: GET_CUSTOM_PROVIDER
-    const isMyCustomProvider = (provider: CustomProvider): provider is MyCustomProvider =>
-        typeof (provider as MyCustomProvider).customAction === 'function';
-
-    const provider = getCustomProvider(appKit, { id: 'my-provider', guard: isMyCustomProvider });
+    const provider = getCustomProvider<MyCustomProvider>(appKit, { id: 'my-provider' });
 
     if (provider) {
         console.log('Custom provider is available');

--- a/demo/examples/src/appkit/actions/providers/get-custom-provider.ts
+++ b/demo/examples/src/appkit/actions/providers/get-custom-provider.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { AppKit, CustomProvider } from '@ton/appkit';
+import { getCustomProvider } from '@ton/appkit';
+
+interface MyCustomProvider extends CustomProvider {
+    customAction: (params: unknown) => Promise<void>;
+}
+
+export const getCustomProviderExample = (appKit: AppKit) => {
+    // SAMPLE_START: GET_CUSTOM_PROVIDER
+    const isMyCustomProvider = (provider: CustomProvider): provider is MyCustomProvider =>
+        typeof (provider as MyCustomProvider).customAction === 'function';
+
+    const provider = getCustomProvider(appKit, { id: 'my-provider', guard: isMyCustomProvider });
+
+    if (provider) {
+        console.log('Custom provider is available');
+    }
+    // SAMPLE_END: GET_CUSTOM_PROVIDER
+};

--- a/demo/examples/src/appkit/actions/providers/providers.test.ts
+++ b/demo/examples/src/appkit/actions/providers/providers.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AppKit } from '@ton/appkit';
+import { Network } from '@ton/walletkit';
+
+import { getCustomProviderExample } from './get-custom-provider';
+
+describe('Provider Actions Examples (Integration)', () => {
+    let appKit: AppKit;
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        appKit = new AppKit({
+            networks: { [Network.mainnet().chainId]: {} },
+        });
+    });
+
+    afterEach(() => {
+        consoleSpy.mockRestore();
+    });
+
+    describe('getCustomProviderExample', () => {
+        it('should log when custom provider is available', () => {
+            const provider = { providerId: 'my-provider', type: 'custom' as const, customAction: async () => {} };
+            appKit.registerProvider(provider);
+            getCustomProviderExample(appKit);
+            expect(consoleSpy).toHaveBeenCalledWith('Custom provider is available');
+        });
+
+        it('should not log when provider is not registered', () => {
+            getCustomProviderExample(appKit);
+            expect(consoleSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/demo/examples/src/appkit/hooks/providers/providers.test.tsx
+++ b/demo/examples/src/appkit/hooks/providers/providers.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createWrapper } from '../../../__tests__/test-utils';
+import { UseCustomProviderExample } from './use-custom-provider';
+
+describe('Provider Hooks Examples', () => {
+    let mockAppKit: any;
+
+    beforeEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+
+        mockAppKit = {
+            emitter: { on: vi.fn(() => () => {}), off: vi.fn() },
+            connectors: [],
+            customProvidersManager: { getProvider: vi.fn().mockReturnValue(undefined) },
+        };
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    describe('UseCustomProviderExample', () => {
+        it('should show not registered message when provider is absent', () => {
+            render(<UseCustomProviderExample />, { wrapper: createWrapper(mockAppKit) });
+            expect(screen.getByText('Custom provider not registered')).toBeDefined();
+        });
+
+        it('should show ready message when provider is registered', () => {
+            mockAppKit.customProvidersManager.getProvider = vi.fn().mockReturnValue({
+                providerId: 'my-provider',
+                type: 'custom',
+                customAction: vi.fn(),
+            });
+
+            render(<UseCustomProviderExample />, { wrapper: createWrapper(mockAppKit) });
+            expect(screen.getByText('Custom provider is ready')).toBeDefined();
+        });
+    });
+});

--- a/demo/examples/src/appkit/hooks/providers/use-custom-provider.tsx
+++ b/demo/examples/src/appkit/hooks/providers/use-custom-provider.tsx
@@ -13,12 +13,9 @@ interface MyCustomProvider extends CustomProvider {
     customAction: (params: unknown) => Promise<void>;
 }
 
-const isMyCustomProvider = (provider: CustomProvider): provider is MyCustomProvider =>
-    typeof (provider as MyCustomProvider).customAction === 'function';
-
 export const UseCustomProviderExample = () => {
     // SAMPLE_START: USE_CUSTOM_PROVIDER
-    const provider = useCustomProvider('my-provider', isMyCustomProvider);
+    const provider = useCustomProvider<MyCustomProvider>('my-provider');
 
     if (!provider) {
         return <div>Custom provider not registered</div>;

--- a/demo/examples/src/appkit/hooks/providers/use-custom-provider.tsx
+++ b/demo/examples/src/appkit/hooks/providers/use-custom-provider.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { CustomProvider } from '@ton/appkit';
+import { useCustomProvider } from '@ton/appkit-react';
+
+interface MyCustomProvider extends CustomProvider {
+    customAction: (params: unknown) => Promise<void>;
+}
+
+const isMyCustomProvider = (provider: CustomProvider): provider is MyCustomProvider =>
+    typeof (provider as MyCustomProvider).customAction === 'function';
+
+export const UseCustomProviderExample = () => {
+    // SAMPLE_START: USE_CUSTOM_PROVIDER
+    const provider = useCustomProvider('my-provider', isMyCustomProvider);
+
+    if (!provider) {
+        return <div>Custom provider not registered</div>;
+    }
+
+    return <div>Custom provider is ready</div>;
+    // SAMPLE_END: USE_CUSTOM_PROVIDER
+};

--- a/packages/appkit-react/docs/hooks.md
+++ b/packages/appkit-react/docs/hooks.md
@@ -1350,7 +1350,7 @@ return <p>{hasSignMessageSupport ? 'Wallet supports SignMessage' : 'SignMessage 
 Hook to get a registered custom provider by id.
 
 ```tsx
-const provider = useCustomProvider('my-provider', isMyCustomProvider);
+const provider = useCustomProvider<MyCustomProvider>('my-provider');
 
 if (!provider) {
     return <div>Custom provider not registered</div>;

--- a/packages/appkit-react/docs/hooks.md
+++ b/packages/appkit-react/docs/hooks.md
@@ -1345,6 +1345,20 @@ const hasSignMessageSupport = useSignMessageSupport();
 return <p>{hasSignMessageSupport ? 'Wallet supports SignMessage' : 'SignMessage not supported'}</p>;
 ```
 
+### `useCustomProvider`
+
+Hook to get a registered custom provider by id.
+
+```tsx
+const provider = useCustomProvider('my-provider', isMyCustomProvider);
+
+if (!provider) {
+    return <div>Custom provider not registered</div>;
+}
+
+return <div>Custom provider is ready</div>;
+```
+
 <!--
 This file is auto-generated. Do not edit manually.
 Changes will be overwritten when running the docs update script.

--- a/packages/appkit-react/src/features/providers/hooks/use-custom-provider.ts
+++ b/packages/appkit-react/src/features/providers/hooks/use-custom-provider.ts
@@ -13,13 +13,11 @@ import type { CustomProvider } from '@ton/appkit';
 import { useAppKit } from '../../settings/hooks/use-app-kit';
 
 /**
- * Hook to get a registered custom provider by id, verified and narrowed by the
- * guard. Reactive to custom provider registrations.
+ * Hook to get a registered custom provider by id. Pass the expected type as a
+ * generic argument to narrow the returned provider. Reactive to custom provider
+ * registrations.
  */
-export const useCustomProvider = <T extends CustomProvider>(
-    id: string,
-    guard: (provider: CustomProvider) => provider is T,
-): T | undefined => {
+export const useCustomProvider = <T extends CustomProvider = CustomProvider>(id: string): T | undefined => {
     const appKit = useAppKit();
 
     const subscribe = useCallback(
@@ -30,8 +28,8 @@ export const useCustomProvider = <T extends CustomProvider>(
     );
 
     const getSnapshot = useCallback(() => {
-        return getCustomProvider(appKit, { id, guard });
-    }, [appKit, id, guard]);
+        return getCustomProvider<T>(appKit, { id });
+    }, [appKit, id]);
 
     return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 };

--- a/packages/appkit-react/src/features/providers/hooks/use-custom-provider.ts
+++ b/packages/appkit-react/src/features/providers/hooks/use-custom-provider.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useSyncExternalStore, useCallback } from 'react';
+import { getCustomProvider, watchCustomProviders } from '@ton/appkit';
+import type { CustomProvider } from '@ton/appkit';
+
+import { useAppKit } from '../../settings/hooks/use-app-kit';
+
+/**
+ * Hook to get a registered custom provider by id, verified and narrowed by the
+ * guard. Reactive to custom provider registrations.
+ */
+export const useCustomProvider = <T extends CustomProvider>(
+    id: string,
+    guard: (provider: CustomProvider) => provider is T,
+): T | undefined => {
+    const appKit = useAppKit();
+
+    const subscribe = useCallback(
+        (onChange: () => void) => {
+            return watchCustomProviders(appKit, { onChange });
+        },
+        [appKit],
+    );
+
+    const getSnapshot = useCallback(() => {
+        return getCustomProvider(appKit, { id, guard });
+    }, [appKit, id, guard]);
+
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+};

--- a/packages/appkit-react/src/features/providers/index.ts
+++ b/packages/appkit-react/src/features/providers/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export { useCustomProvider } from './hooks/use-custom-provider';

--- a/packages/appkit-react/src/index.ts
+++ b/packages/appkit-react/src/index.ts
@@ -42,5 +42,6 @@ export * from './features/swap';
 export * from './features/signing';
 export * from './features/staking';
 export * from './features/gasless';
+export * from './features/providers';
 
 export * from './types/appkit-ui-token';

--- a/packages/appkit/docs/actions.md
+++ b/packages/appkit/docs/actions.md
@@ -916,13 +916,9 @@ const unsubscribe = watchSignMessageSupport(appKit, {
 
 Get a registered custom provider by id.
 
-```ts
-const isMyCustomProvider = (provider: CustomProvider): provider is MyCustomProvider =>
-    typeof (provider as MyCustomProvider).customAction === 'function';
-
-const provider = getCustomProvider(appKit, {
+```tsx
+const provider = getCustomProvider<MyCustomProvider>(appKit, {
     id: 'my-provider',
-    guard: isMyCustomProvider,
 });
 
 if (provider) {

--- a/packages/appkit/docs/actions.md
+++ b/packages/appkit/docs/actions.md
@@ -718,7 +718,7 @@ const quote = await getGaslessQuote(appKit, {
         {
             address: 'EQ...jetton_wallet_address',
             amount: '60000000', // 0.06 TON gas budget
-            payload: 'te6cckEBAQEAAgAAAA==' as never,
+            payload: asBase64('te6cckEBAQEAAgAAAA=='),
         },
     ],
 });
@@ -910,6 +910,24 @@ const unsubscribe = watchSignMessageSupport(appKit, {
 });
 
 // Later: unsubscribe();
+```
+
+### `getCustomProvider`
+
+Get a registered custom provider by id.
+
+```ts
+const isMyCustomProvider = (provider: CustomProvider): provider is MyCustomProvider =>
+    typeof (provider as MyCustomProvider).customAction === 'function';
+
+const provider = getCustomProvider(appKit, {
+    id: 'my-provider',
+    guard: isMyCustomProvider,
+});
+
+if (provider) {
+    console.log('Custom provider is available');
+}
 ```
 
 <!--

--- a/packages/appkit/src/actions/index.ts
+++ b/packages/appkit/src/actions/index.ts
@@ -107,6 +107,16 @@ export { transferNft, type TransferNftParameters, type TransferNftReturnType } f
 
 // Providers
 export { registerProvider, type RegisterProviderOptions } from './providers/register-provider';
+export {
+    getCustomProvider,
+    type GetCustomProviderOptions,
+    type GetCustomProviderReturnType,
+} from './providers/get-custom-provider';
+export {
+    watchCustomProviders,
+    type WatchCustomProvidersParameters,
+    type WatchCustomProvidersReturnType,
+} from './providers/watch-custom-providers';
 
 // Gasless
 export { getGaslessManager, type GetGaslessManagerReturnType } from './gasless/get-gasless-manager';

--- a/packages/appkit/src/actions/providers/get-custom-provider.ts
+++ b/packages/appkit/src/actions/providers/get-custom-provider.ts
@@ -9,19 +9,19 @@
 import type { AppKit } from '../../core/app-kit';
 import type { CustomProvider } from '../../providers';
 
-export interface GetCustomProviderOptions<T extends CustomProvider = CustomProvider> {
+export interface GetCustomProviderOptions {
     id: string;
-    guard: (provider: CustomProvider) => provider is T;
 }
 
 export type GetCustomProviderReturnType<T extends CustomProvider = CustomProvider> = T | undefined;
 
 /**
- * Get a registered custom provider by id, verified and narrowed by the guard.
+ * Get a registered custom provider by id. Pass the expected type as a generic
+ * argument to narrow the returned provider.
  */
-export const getCustomProvider = <T extends CustomProvider>(
+export const getCustomProvider = <T extends CustomProvider = CustomProvider>(
     appKit: AppKit,
-    options: GetCustomProviderOptions<T>,
+    options: GetCustomProviderOptions,
 ): GetCustomProviderReturnType<T> => {
-    return appKit.customProvidersManager.getProvider(options.id, options.guard);
+    return appKit.customProvidersManager.getProvider<T>(options.id);
 };

--- a/packages/appkit/src/actions/providers/get-custom-provider.ts
+++ b/packages/appkit/src/actions/providers/get-custom-provider.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { AppKit } from '../../core/app-kit';
+import type { CustomProvider } from '../../providers';
+
+export interface GetCustomProviderOptions<T extends CustomProvider = CustomProvider> {
+    id: string;
+    guard: (provider: CustomProvider) => provider is T;
+}
+
+export type GetCustomProviderReturnType<T extends CustomProvider = CustomProvider> = T | undefined;
+
+/**
+ * Get a registered custom provider by id, verified and narrowed by the guard.
+ */
+export const getCustomProvider = <T extends CustomProvider>(
+    appKit: AppKit,
+    options: GetCustomProviderOptions<T>,
+): GetCustomProviderReturnType<T> => {
+    return appKit.customProvidersManager.getProvider(options.id, options.guard);
+};

--- a/packages/appkit/src/actions/providers/watch-custom-providers.ts
+++ b/packages/appkit/src/actions/providers/watch-custom-providers.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { AppKit } from '../../core/app-kit';
+
+export interface WatchCustomProvidersParameters {
+    onChange: () => void;
+}
+
+export type WatchCustomProvidersReturnType = () => void;
+
+/**
+ * Watch for custom provider registrations
+ */
+export const watchCustomProviders = (
+    appKit: AppKit,
+    parameters: WatchCustomProvidersParameters,
+): WatchCustomProvidersReturnType => {
+    const { onChange } = parameters;
+
+    return appKit.emitter.on('provider:registered', (event) => {
+        if (event.payload.type === 'custom') onChange();
+    });
+};

--- a/packages/appkit/src/core/app-kit/services/app-kit.ts
+++ b/packages/appkit/src/core/app-kit/services/app-kit.ts
@@ -24,6 +24,8 @@ import { Network } from '../../../types/network';
 import type { AppKitCache } from '../../cache';
 import { LruAppKitCache } from '../../cache';
 import type { AppKitProvider } from '../../../types/provider';
+import { CustomProvidersManager } from '../../../providers';
+import type { CustomProvider } from '../../../providers';
 
 /**
  * Central hub for wallet management.
@@ -36,6 +38,7 @@ export class AppKit {
     readonly swapManager: SwapManager;
     readonly stakingManager: StakingManager;
     readonly gaslessManager: GaslessManager;
+    readonly customProvidersManager: CustomProvidersManager;
 
     readonly networkManager: AppKitNetworkManager;
     readonly streamingManager: StreamingManager;
@@ -60,6 +63,7 @@ export class AppKit {
         this.swapManager = new SwapManager(() => this.createFactoryContext());
         this.stakingManager = new StakingManager(() => this.createFactoryContext());
         this.gaslessManager = new GaslessManager(() => this.createFactoryContext());
+        this.customProvidersManager = new CustomProvidersManager(() => this.createFactoryContext());
         this.streamingManager = new StreamingManager(() => this.createFactoryContext());
 
         if (config.connectors) {
@@ -132,6 +136,9 @@ export class AppKit {
                 break;
             case 'gasless':
                 this.gaslessManager.registerProvider(provider as GaslessProviderInterface);
+                break;
+            case 'custom':
+                this.customProvidersManager.registerProvider(provider as CustomProvider);
                 break;
             default:
                 throw new Error('Unknown provider type');

--- a/packages/appkit/src/index.ts
+++ b/packages/appkit/src/index.ts
@@ -36,6 +36,7 @@ export * from './connectors/tonconnect';
 export * from './swap';
 export * from './staking';
 export * from './gasless';
+export * from './providers';
 
 // Actions
 export * from './actions';

--- a/packages/appkit/src/providers/index.ts
+++ b/packages/appkit/src/providers/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export { CustomProvidersManager } from '@ton/walletkit';
+
+export type { CustomProvider } from '@ton/walletkit';

--- a/packages/appkit/src/types/provider.ts
+++ b/packages/appkit/src/types/provider.ts
@@ -11,6 +11,7 @@ import type {
     StakingProviderInterface,
     StreamingProvider,
     GaslessProviderInterface,
+    CustomProvider,
 } from '@ton/walletkit';
 
 /**
@@ -20,4 +21,5 @@ export type AppKitProvider =
     | SwapProviderInterface
     | StakingProviderInterface
     | StreamingProvider
-    | GaslessProviderInterface;
+    | GaslessProviderInterface
+    | CustomProvider;

--- a/packages/walletkit/src/core/TonWalletKit.ts
+++ b/packages/walletkit/src/core/TonWalletKit.ts
@@ -46,6 +46,8 @@ import type { BridgeManager } from './BridgeManager';
 import type { BridgeEventMessageInfo, InjectedToExtensionBridgeRequestPayload } from '../types/jsBridge';
 import type { ApiClient, StakingProviderInterface, StreamingProvider, SwapProviderInterface } from '../api/interfaces';
 import { StreamingManager } from '../streaming/StreamingManager';
+import { CustomProvidersManager } from '../providers';
+import type { CustomProvider } from '../providers';
 import type { WalletKitEvents, WalletKitEventEmitter } from '../types/emitter';
 import { AnalyticsManager } from '../analytics';
 import { getDeviceInfoForWallet } from '../utils/getDefaultWalletConfig';
@@ -103,6 +105,7 @@ export class TonWalletKit implements ITonWalletKit {
     private streamingManager: StreamingManager;
     private stakingManager: StakingManager;
     private gaslessManager: GaslessManager;
+    private customProvidersManager: CustomProvidersManager;
     private initializer: Initializer;
     private eventProcessor!: StorageEventProcessor;
     private bridgeManager!: BridgeManager;
@@ -149,6 +152,8 @@ export class TonWalletKit implements ITonWalletKit {
         this.stakingManager = new StakingManager(() => this.createFactoryContext());
         // Initialize GaslessManager
         this.gaslessManager = new GaslessManager(() => this.createFactoryContext());
+        // Initialize CustomProvidersManager
+        this.customProvidersManager = new CustomProvidersManager(() => this.createFactoryContext());
 
         this.eventEmitter.on('restoreConnection', async ({ payload: event }) => {
             if (!event.domain) {
@@ -881,6 +886,9 @@ export class TonWalletKit implements ITonWalletKit {
             case 'gasless':
                 this.gaslessManager.registerProvider(provider as GaslessProvider);
                 break;
+            case 'custom':
+                this.customProvidersManager.registerProvider(provider as CustomProvider);
+                break;
             default:
                 throw new Error('Unknown provider type');
         }
@@ -928,6 +936,13 @@ export class TonWalletKit implements ITonWalletKit {
      */
     get gasless(): GaslessManager {
         return this.gaslessManager;
+    }
+
+    /**
+     * Custom providers API access
+     */
+    get customProviders(): CustomProvidersManager {
+        return this.customProvidersManager;
     }
 
     /**

--- a/packages/walletkit/src/index.ts
+++ b/packages/walletkit/src/index.ts
@@ -166,3 +166,5 @@ export { StreamingManager } from './streaming';
 export type { StreamingProvider, StreamingProviderFactory } from './api/interfaces/StreamingProvider';
 export type { StreamingAPI } from './api/interfaces/StreamingAPI';
 export type { ProviderFactoryContext } from './types/factory';
+export { CustomProvidersManager } from './providers';
+export type { CustomProvider } from './providers';

--- a/packages/walletkit/src/providers/CustomProvider.ts
+++ b/packages/walletkit/src/providers/CustomProvider.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { BaseProvider } from '../api/models';
+
+/**
+ * A provider with custom functionality registered by a third party.
+ * Extend this interface to add your own methods.
+ *
+ * @example
+ * interface MyCustomProvider extends CustomProvider {
+ *     customAction(params: CustomParams): Promise<void>;
+ * }
+ */
+export interface CustomProvider extends BaseProvider {
+    readonly type: 'custom';
+}

--- a/packages/walletkit/src/providers/CustomProvidersManager.spec.ts
+++ b/packages/walletkit/src/providers/CustomProvidersManager.spec.ts
@@ -18,9 +18,6 @@ interface TestProvider extends CustomProvider {
     customAction: () => Promise<void>;
 }
 
-const isTestProvider = (provider: CustomProvider): provider is TestProvider =>
-    typeof (provider as TestProvider).customAction === 'function';
-
 const makeManager = (): { manager: CustomProvidersManager; emitter: EventEmitter<SharedKitEvents> } => {
     const emitter = new EventEmitter<SharedKitEvents>();
     const ctx: ProviderFactoryContext = {
@@ -43,18 +40,13 @@ describe('CustomProvidersManager', () => {
         manager = makeManager().manager;
     });
 
-    it('registers and retrieves a provider by id and guard', () => {
+    it('registers and retrieves a provider by id', () => {
         manager.registerProvider(makeProvider('my'));
-        expect(manager.getProvider('my', isTestProvider)?.providerId).toBe('my');
+        expect(manager.getProvider<TestProvider>('my')?.providerId).toBe('my');
     });
 
     it('returns undefined for an unknown provider', () => {
-        expect(manager.getProvider('missing', isTestProvider)).toBeUndefined();
-    });
-
-    it('returns undefined when the guard rejects the registered provider', () => {
-        manager.registerProvider({ providerId: 'wrong', type: 'custom' as const });
-        expect(manager.getProvider('wrong', isTestProvider)).toBeUndefined();
+        expect(manager.getProvider('missing')).toBeUndefined();
     });
 
     it('resolves a provider factory using the factory context', () => {
@@ -69,7 +61,7 @@ describe('CustomProvidersManager', () => {
         const second = makeProvider('dup');
         manager.registerProvider(makeProvider('dup'));
         manager.registerProvider(second);
-        expect(manager.getProvider('dup', isTestProvider)).toBe(second);
+        expect(manager.getProvider('dup')).toBe(second);
         expect(manager.getRegisteredProviders()).toEqual(['dup']);
     });
 

--- a/packages/walletkit/src/providers/CustomProvidersManager.spec.ts
+++ b/packages/walletkit/src/providers/CustomProvidersManager.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { EventEmitter } from '../core/EventEmitter';
+import type { ProviderFactoryContext } from '../types/factory';
+import type { SharedKitEvents } from '../types/emitter';
+import type { CustomProvider } from './CustomProvider';
+import { CustomProvidersManager } from './CustomProvidersManager';
+
+interface TestProvider extends CustomProvider {
+    customAction: () => Promise<void>;
+}
+
+const isTestProvider = (provider: CustomProvider): provider is TestProvider =>
+    typeof (provider as TestProvider).customAction === 'function';
+
+const makeManager = (): { manager: CustomProvidersManager; emitter: EventEmitter<SharedKitEvents> } => {
+    const emitter = new EventEmitter<SharedKitEvents>();
+    const ctx: ProviderFactoryContext = {
+        eventEmitter: emitter,
+        networkManager: undefined as never,
+    };
+    return { manager: new CustomProvidersManager(() => ctx), emitter };
+};
+
+const makeProvider = (providerId: string): TestProvider => ({
+    providerId,
+    type: 'custom',
+    customAction: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('CustomProvidersManager', () => {
+    let manager: CustomProvidersManager;
+
+    beforeEach(() => {
+        manager = makeManager().manager;
+    });
+
+    it('registers and retrieves a provider by id and guard', () => {
+        manager.registerProvider(makeProvider('my'));
+        expect(manager.getProvider('my', isTestProvider)?.providerId).toBe('my');
+    });
+
+    it('returns undefined for an unknown provider', () => {
+        expect(manager.getProvider('missing', isTestProvider)).toBeUndefined();
+    });
+
+    it('returns undefined when the guard rejects the registered provider', () => {
+        manager.registerProvider({ providerId: 'wrong', type: 'custom' as const });
+        expect(manager.getProvider('wrong', isTestProvider)).toBeUndefined();
+    });
+
+    it('resolves a provider factory using the factory context', () => {
+        manager.registerProvider((ctx) => {
+            expect(ctx.eventEmitter).toBeDefined();
+            return makeProvider('from-factory');
+        });
+        expect(manager.hasProvider('from-factory')).toBe(true);
+    });
+
+    it('replaces a provider registered with the same id', () => {
+        const second = makeProvider('dup');
+        manager.registerProvider(makeProvider('dup'));
+        manager.registerProvider(second);
+        expect(manager.getProvider('dup', isTestProvider)).toBe(second);
+        expect(manager.getRegisteredProviders()).toEqual(['dup']);
+    });
+
+    it('lists all registered provider ids', () => {
+        manager.registerProvider(makeProvider('a'));
+        manager.registerProvider(makeProvider('b'));
+        expect(manager.getRegisteredProviders()).toEqual(['a', 'b']);
+    });
+
+    it('reports whether a provider is registered', () => {
+        expect(manager.hasProvider('x')).toBe(false);
+        manager.registerProvider(makeProvider('x'));
+        expect(manager.hasProvider('x')).toBe(true);
+    });
+
+    it('emits provider:registered on registration', () => {
+        const { manager: mgr, emitter } = makeManager();
+        const listener = vi.fn();
+        emitter.on('provider:registered', listener);
+        mgr.registerProvider(makeProvider('my'));
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/walletkit/src/providers/CustomProvidersManager.ts
+++ b/packages/walletkit/src/providers/CustomProvidersManager.ts
@@ -17,9 +17,8 @@ import type { CustomProvider } from './CustomProvider';
  * Registry for custom providers (`type: 'custom'`), keyed by `providerId`.
  *
  * Unlike the defi managers, a custom provider exposes no SDK-defined API.
- * Consumers register their own implementation and retrieve it through a
- * caller-supplied type guard, which both narrows the type and verifies at
- * runtime that the registered provider really matches.
+ * Consumers register their own implementation and retrieve it by id, passing
+ * the expected type as a generic argument to narrow the returned provider.
  */
 export class CustomProvidersManager {
     public createFactoryContext: () => ProviderFactoryContext;
@@ -48,17 +47,12 @@ export class CustomProvidersManager {
     }
 
     /**
-     * Get a registered custom provider by id, verified and narrowed by the guard.
+     * Get a registered custom provider by id.
      * @param providerId - Id the provider was registered under
-     * @param guard - Type guard confirming the provider is of type `T`
-     * @returns The provider when present and the guard passes, otherwise undefined
+     * @returns The provider when present, otherwise undefined
      */
-    getProvider<T extends CustomProvider>(
-        providerId: string,
-        guard: (provider: CustomProvider) => provider is T,
-    ): T | undefined {
-        const provider = this.providers.get(providerId);
-        return provider && guard(provider) ? provider : undefined;
+    getProvider<T extends CustomProvider>(providerId: string): T | undefined {
+        return this.providers.get(providerId) as T | undefined;
     }
 
     /**

--- a/packages/walletkit/src/providers/CustomProvidersManager.ts
+++ b/packages/walletkit/src/providers/CustomProvidersManager.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { resolveProvider } from '../types';
+import type { ProviderInput } from '../types';
+import type { ProviderFactoryContext } from '../types/factory';
+import type { SharedKitEvents } from '../types/emitter';
+import type { EventEmitter } from '../core/EventEmitter';
+import type { CustomProvider } from './CustomProvider';
+
+/**
+ * Registry for custom providers (`type: 'custom'`), keyed by `providerId`.
+ *
+ * Unlike the defi managers, a custom provider exposes no SDK-defined API.
+ * Consumers register their own implementation and retrieve it through a
+ * caller-supplied type guard, which both narrows the type and verifies at
+ * runtime that the registered provider really matches.
+ */
+export class CustomProvidersManager {
+    public createFactoryContext: () => ProviderFactoryContext;
+
+    private readonly providers = new Map<string, CustomProvider>();
+    private readonly eventEmitter: EventEmitter<SharedKitEvents>;
+
+    constructor(createFactoryContext: () => ProviderFactoryContext) {
+        this.createFactoryContext = createFactoryContext;
+        this.eventEmitter = createFactoryContext().eventEmitter;
+    }
+
+    /**
+     * Register a custom provider. Replaces any existing provider with the same id.
+     * Emits `provider:registered`.
+     * @param input - Provider instance or factory that produces one
+     */
+    registerProvider<T extends CustomProvider>(input: ProviderInput<T>): void {
+        const provider = resolveProvider(input, this.createFactoryContext());
+        this.providers.set(provider.providerId, provider);
+        this.eventEmitter.emit(
+            'provider:registered',
+            { providerId: provider.providerId, type: provider.type },
+            'custom-providers-manager',
+        );
+    }
+
+    /**
+     * Get a registered custom provider by id, verified and narrowed by the guard.
+     * @param providerId - Id the provider was registered under
+     * @param guard - Type guard confirming the provider is of type `T`
+     * @returns The provider when present and the guard passes, otherwise undefined
+     */
+    getProvider<T extends CustomProvider>(
+        providerId: string,
+        guard: (provider: CustomProvider) => provider is T,
+    ): T | undefined {
+        const provider = this.providers.get(providerId);
+        return provider && guard(provider) ? provider : undefined;
+    }
+
+    /**
+     * Check if a custom provider is registered
+     */
+    hasProvider(providerId: string): boolean {
+        return this.providers.has(providerId);
+    }
+
+    /**
+     * Get the ids of all registered custom providers
+     */
+    getRegisteredProviders(): string[] {
+        return Array.from(this.providers.keys());
+    }
+}

--- a/packages/walletkit/src/providers/index.ts
+++ b/packages/walletkit/src/providers/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) TonTech.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export { CustomProvidersManager } from './CustomProvidersManager';
+export type { CustomProvider } from './CustomProvider';

--- a/template/packages/appkit-react/docs/hooks.md
+++ b/template/packages/appkit-react/docs/hooks.md
@@ -372,4 +372,10 @@ Hook to check whether the selected wallet advertises the `SignMessage` feature (
 
 %%demo/examples/src/appkit/hooks/wallets#USE_SIGN_MESSAGE_SUPPORT%%
 
+### `useCustomProvider`
+
+Hook to get a registered custom provider by id.
+
+%%demo/examples/src/appkit/hooks/providers#USE_CUSTOM_PROVIDER%%
+
 

--- a/template/packages/appkit/docs/actions.md
+++ b/template/packages/appkit/docs/actions.md
@@ -462,3 +462,9 @@ Whether the selected wallet advertises the `SignMessage` feature (required for g
 Watch whether the selected wallet supports `SignMessage`, re-evaluated on every selection change.
 
 %%demo/examples/src/appkit/actions/wallets#WATCH_SIGN_MESSAGE_SUPPORT%%
+
+### `getCustomProvider`
+
+Get a registered custom provider by id.
+
+%%demo/examples/src/appkit/actions/providers#GET_CUSTOM_PROVIDER%%


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom provider support across the SDK, including a custom provider registry and access via `customProviders`.
  * Added `getCustomProvider` and `watchCustomProviders` for retrieving and reacting to custom provider registrations.
  * Added `useCustomProvider` React hook for accessing registered custom providers by `id`.
* **Documentation**
  * Updated action and hook docs with `getCustomProvider`/`useCustomProvider` usage guidance.
  * Added runnable examples for custom provider actions and the React hook.
* **Tests**
  * Added integration tests for the custom provider action and React hook examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->