### PR TITLE
Rename token symbol and name from 'GRAM' to 'GRM'

### DIFF
--- a/packages/mcp/src/tools/known-jettons-tools.ts
+++ b/packages/mcp/src/tools/known-jettons-tools.ts
@@ -38,8 +38,8 @@ export const KNOWN_JETTONS = [
         decimals: 9,
     },
     {
-        symbol: 'GRAM',
-        name: 'Gram',
+        symbol: 'GRM',
+        name: 'Grm',
         address: 'EQC47093oX5Xhb0xuk2lCr2RhS8rj-vul61u4W2UH5ORmG_O',
         decimals: 9,
     },


### PR DESCRIPTION
Just because @durov did "DMCA" of this jetton's branding - all AI models get totally insane and confused.

$GRAM #MTONGA!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token symbol and name in the known jettons list for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->