### PR TITLE
Create appkit manifest

### DIFF
--- a/.github/workflows/create_ton_appkit_test.yml
+++ b/.github/workflows/create_ton_appkit_test.yml
@@ -57,25 +57,15 @@ jobs:
           TARBALL="$(ls create-ton-appkit-*.tgz)"
           echo "TARBALL=$(pwd)/$TARBALL" >> "$GITHUB_ENV"
 
-      - name: Scaffold a project from the local tarball (${{ matrix.pm }})
+      - name: Scaffold a project from the local tarball
         shell: bash
         working-directory: ${{ runner.temp }}
         run: |
           set -euo pipefail
           APP_URL=https://example.com
-          args=(my-app -y --template react --app-url "$APP_URL")
           tname="$(basename "$TARBALL")"
-          case "${{ matrix.pm }}" in
-            npm)  npm exec --yes --package="$TARBALL" -- create-ton-appkit "${args[@]}" ;;
-            pnpm) pnpm --package="$TARBALL" dlx create-ton-appkit "${args[@]}" ;;
-            yarn) cp "$TARBALL" "./$tname"
-                  yarn global add "file:./$tname"
-                  export PATH="$(yarn global bin):$PATH"
-                  create-ton-appkit "${args[@]}" ;;
-            bun)  bun add -g "$TARBALL"
-                  export PATH="$HOME/.bun/bin:$PATH"
-                  create-ton-appkit "${args[@]}" ;;
-          esac
+          cp "$TARBALL" "./$tname"
+          npm exec --yes --package="./$tname" -- create-ton-appkit my-app -y --template react --app-url "$APP_URL"
           # Sanity-check the generated TonConnect manifest got the requested app URL.
           manifest="my-app/public/tonconnect-manifest.json"
           grep -q "\"url\": \"$APP_URL\"" "$manifest"

--- a/.github/workflows/create_ton_appkit_test.yml
+++ b/.github/workflows/create_ton_appkit_test.yml
@@ -57,15 +57,24 @@ jobs:
           TARBALL="$(ls create-ton-appkit-*.tgz)"
           echo "TARBALL=$(pwd)/$TARBALL" >> "$GITHUB_ENV"
 
-      - name: Scaffold a project from the local tarball
+      - name: Scaffold a project via "<pm> run" (${{ matrix.pm }})
         shell: bash
         working-directory: ${{ runner.temp }}
         run: |
           set -euo pipefail
           APP_URL=https://example.com
-          tname="$(basename "$TARBALL")"
-          cp "$TARBALL" "./$tname"
-          npm exec --yes --package="./$tname" -- create-ton-appkit my-app -y --template react --app-url "$APP_URL"
+          tname="$(basename "$TARBALL")"; cp "$TARBALL" "./$tname"
+          
+          printf '{"name":"_scaffolder","private":true,"scripts":{"scaffold":"create-ton-appkit my-app -y --template react --app-url %s"}}' "$APP_URL" > package.json
+          npm i "./$tname" >/dev/null 2>&1
+          case "${{ matrix.pm }}" in
+            npm)  npm run scaffold ;;
+            pnpm) pnpm run scaffold ;;
+            yarn) yarn run scaffold ;;
+            bun)  bun run scaffold ;;
+          esac
+
+          rm -rf node_modules package.json package-lock.json pnpm-lock.yaml yarn.lock bun.lock bun.lockb "$tname"
           # Sanity-check the generated TonConnect manifest got the requested app URL.
           manifest="my-app/public/tonconnect-manifest.json"
           grep -q "\"url\": \"$APP_URL\"" "$manifest"

--- a/.github/workflows/create_ton_appkit_test.yml
+++ b/.github/workflows/create_ton_appkit_test.yml
@@ -64,11 +64,12 @@ jobs:
           set -euo pipefail
           APP_URL=https://example.com
           args=(my-app -y --template react --app-url "$APP_URL")
-          tdir="$(dirname "$TARBALL")"; tname="$(basename "$TARBALL")"
+          tname="$(basename "$TARBALL")"
           case "${{ matrix.pm }}" in
             npm)  npm exec --yes --package="$TARBALL" -- create-ton-appkit "${args[@]}" ;;
             pnpm) pnpm --package="$TARBALL" dlx create-ton-appkit "${args[@]}" ;;
-            yarn) (cd "$tdir" && yarn global add "file:$tname")
+            yarn) cp "$TARBALL" "./$tname"
+                  yarn global add "file:./$tname"
                   export PATH="$(yarn global bin):$PATH"
                   create-ton-appkit "${args[@]}" ;;
             bun)  bun add -g "$TARBALL"

--- a/.github/workflows/create_ton_appkit_test.yml
+++ b/.github/workflows/create_ton_appkit_test.yml
@@ -57,14 +57,31 @@ jobs:
           TARBALL="$(ls create-ton-appkit-*.tgz)"
           echo "TARBALL=$(pwd)/$TARBALL" >> "$GITHUB_ENV"
 
-      - name: Install create-ton-appkit globally
-        shell: bash
-        run: npm install -g "$TARBALL"
-
-      - name: Scaffold a project
+      - name: Scaffold a project via "create" (${{ matrix.pm }})
         shell: bash
         working-directory: ${{ runner.temp }}
-        run: create-ton-appkit my-app -y --template react --app-url https://example.com
+        run: |
+          set -euo pipefail
+          # Run the crate's bin straight from the locally built tarball, exercised through
+          # each package manager so the matrix tests the crate itself, not a published copy.
+          APP_URL=https://example.com
+          args=(my-app -y --template react --app-url "$APP_URL")
+          case "${{ matrix.pm }}" in
+            npm)  npm exec --yes --package="$TARBALL" -- create-ton-appkit "${args[@]}" ;;
+            pnpm) pnpm --package="$TARBALL" dlx create-ton-appkit "${args[@]}" ;;
+            # Yarn Classic and Bun have no dlx/exec for a local tarball — install the bin globally, then run it.
+            yarn) yarn global add "file:$TARBALL"
+                  export PATH="$(yarn global bin):$PATH"
+                  create-ton-appkit "${args[@]}" ;;
+            bun)  bun install -g "$TARBALL"
+                  export PATH="$HOME/.bun/bin:$PATH"
+                  create-ton-appkit "${args[@]}" ;;
+          esac
+
+          # Sanity-check the generated TonConnect manifest got the requested app URL.
+          manifest="my-app/public/tonconnect-manifest.json"
+          grep -q "\"url\": \"$APP_URL\"" "$manifest"
+          grep -q "\"iconUrl\": \"$APP_URL/favicon.svg\"" "$manifest"
 
       - name: Install dependencies (${{ matrix.pm }})
         shell: bash

--- a/.github/workflows/create_ton_appkit_test.yml
+++ b/.github/workflows/create_ton_appkit_test.yml
@@ -57,27 +57,24 @@ jobs:
           TARBALL="$(ls create-ton-appkit-*.tgz)"
           echo "TARBALL=$(pwd)/$TARBALL" >> "$GITHUB_ENV"
 
-      - name: Scaffold a project via "create" (${{ matrix.pm }})
+      - name: Scaffold a project from the local tarball (${{ matrix.pm }})
         shell: bash
         working-directory: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          # Run the crate's bin straight from the locally built tarball, exercised through
-          # each package manager so the matrix tests the crate itself, not a published copy.
           APP_URL=https://example.com
           args=(my-app -y --template react --app-url "$APP_URL")
+          tdir="$(dirname "$TARBALL")"; tname="$(basename "$TARBALL")"
           case "${{ matrix.pm }}" in
             npm)  npm exec --yes --package="$TARBALL" -- create-ton-appkit "${args[@]}" ;;
             pnpm) pnpm --package="$TARBALL" dlx create-ton-appkit "${args[@]}" ;;
-            # Yarn Classic and Bun have no dlx/exec for a local tarball — install the bin globally, then run it.
-            yarn) yarn global add "file:$TARBALL"
+            yarn) (cd "$tdir" && yarn global add "file:$tname")
                   export PATH="$(yarn global bin):$PATH"
                   create-ton-appkit "${args[@]}" ;;
-            bun)  bun install -g "$TARBALL"
+            bun)  bun add -g "$TARBALL"
                   export PATH="$HOME/.bun/bin:$PATH"
                   create-ton-appkit "${args[@]}" ;;
           esac
-
           # Sanity-check the generated TonConnect manifest got the requested app URL.
           manifest="my-app/public/tonconnect-manifest.json"
           grep -q "\"url\": \"$APP_URL\"" "$manifest"

--- a/packages/create-ton-appkit/README.md
+++ b/packages/create-ton-appkit/README.md
@@ -31,7 +31,7 @@ pnpm create ton-appkit my-app --template react --app-url https://example.com -y
 |------|-------|-------------|---------|
 | `[project-name]` | | Project directory name | `my-ton-app` |
 | `--template <name>` | `-t` | Template to use | `react` |
-| `--app-url <url>` | | App URL for TonConnect manifest | `https://your-app.example.com` |
+| `--app-url <url>` | | App URL for TonConnect manifest | `https://appkit-template.vercel.app` |
 | `--overwrite` | `-o` | Overwrite existing directory | `false` |
 | `--yes` | `-y` | Accept all defaults (non-interactive) | `false` |
 | `--help` | `-h` | Show help message | |

--- a/packages/create-ton-appkit/src/index.ts
+++ b/packages/create-ton-appkit/src/index.ts
@@ -197,12 +197,12 @@ async function run(): Promise<void> {
     let appUrl = argv['app-url'] as string | undefined;
     if (!appUrl) {
         if (useDefaults) {
-            appUrl = 'https://your-app.example.com';
+            appUrl = 'https://appkit-template.vercel.app';
         } else {
             const result = await prompts.text({
                 message: 'App URL (for TonConnect manifest)',
-                placeholder: 'https://your-app.example.com',
-                defaultValue: 'https://your-app.example.com',
+                placeholder: 'https://appkit-template.vercel.app',
+                defaultValue: 'https://appkit-template.vercel.app',
             });
             if (prompts.isCancel(result)) {
                 prompts.cancel('Cancelled.');

--- a/packages/create-ton-appkit/template-react/_env
+++ b/packages/create-ton-appkit/template-react/_env
@@ -3,4 +3,4 @@
 VITE_TONCENTER_API_KEY=
 
 # Override the TonConnect manifest URL. Defaults to ${origin}/tonconnect-manifest.json.
-# VITE_TONCONNECT_MANIFEST_URL=https://your-app.example.com/tonconnect-manifest.json
+# VITE_TONCONNECT_MANIFEST_URL=https://appkit-template.vercel.app/tonconnect-manifest.json

--- a/packages/create-ton-appkit/template-react/public/tonconnect-manifest.json
+++ b/packages/create-ton-appkit/template-react/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://your-app.example.com",
+    "url": "https://appkit-template.vercel.app",
     "name": "TON AppKit Template",
-    "iconUrl": "https://your-app.example.com/favicon.svg"
+    "iconUrl": "https://appkit-template.vercel.app/favicon.svg"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Documentation**
- Updated the create AppKit README and template environment comments to use `https://appkit-template.vercel.app` as the default App URL.

**Chores**
- Improved the test scaffolding workflow to scaffold from the locally packed CLI tarball and execute with the current package manager.
- Added a post-scaffold validation to verify the TON Connect manifest `url` and `iconUrl` (including favicon).

**Templates**
- Updated the generated TON Connect manifest template and related defaults to target `https://appkit-template.vercel.app`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->