### PR TITLE
chore(mcp): rebrand native asset to "GRAM (ex. TON)"

### DIFF
--- a/.changeset/rename-ton-to-gram.md
+++ b/.changeset/rename-ton-to-gram.md
@@ -22,5 +22,6 @@ All widgets and components now present the native asset as GRAM instead of TON:
 
 **@ton/mcp**
 
-- Tool descriptions and output labels now read GRAM (e.g. "Send GRAM", "Get GRAM balance", amounts rendered as "1.5 GRAM"); raw-unit wording now reads "nano units" instead of "nanoTON".
+- Tool descriptions, docs (README, llms.txt, USAGE_EXAMPLES), and skills now present the native asset as "GRAM (ex. TON)" (e.g. "Send GRAM (ex. TON)", "Get GRAM (ex. TON) balance", amounts rendered as "1.5 GRAM"); raw-unit wording now reads "nano units" instead of "nanoTON".
+- Only the coin is renamed: TON Blockchain / network / DNS / TonProof / config references stay "TON".
 - The tool API is unchanged: the `"TON"` token selector, returned token symbols, and the `nanoTon` output field stay the same.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,8 +4,8 @@ A Model Context Protocol (MCP) server for TON blockchain wallet operations. Buil
 
 ## Features
 
-- **Balance Queries**: Check TON and Jetton balances, view transaction history.
-- **Transfers**: Send TON, Jettons, and NFTs to any address.
+- **Balance Queries**: Check GRAM (ex. TON) and Jetton balances, view transaction history.
+- **Transfers**: Send GRAM (ex. TON), Jettons, and NFTs to any address.
 - **Swaps**: Get quotes for token swaps via DEX aggregators.
 - **NFTs**: List, inspect, and transfer NFTs.
 - **DNS**: Resolve TON DNS-compatible domains and reverse-lookup addresses.
@@ -166,17 +166,17 @@ Soft-delete a stored wallet from the local registry. Removed wallets remain in t
 ### Balance & History
 
 #### `get_balance`
-Get the TON balance of the wallet.
+Get the GRAM (ex. TON) balance of the wallet.
 
-**Returns:** Balance in TON and nanoTON
+**Returns:** Balance in GRAM (ex. TON) and nanoTON
 
 #### `get_balance_by_address`
-Get the TON balance of any address.
+Get the GRAM (ex. TON) balance of any address.
 
 **Parameters:**
 - `address` (required): TON wallet address
 
-**Returns:** Address balance in TON and nanoTON
+**Returns:** Address balance in GRAM (ex. TON) and nanoTON
 
 #### `get_jetton_balance`
 Get the balance of a specific Jetton in the wallet.
@@ -202,7 +202,7 @@ Get metadata for a Jetton master contract.
 - `jettonAddress` (required): Jetton master contract address
 
 #### `get_transactions`
-Get recent transaction history for the wallet (TON transfers, Jetton transfers, swaps, etc.).
+Get recent transaction history for the wallet (GRAM (ex. TON) transfers, Jetton transfers, swaps, etc.).
 
 **Parameters:**
 - `limit` (optional): Maximum number of transactions to return (default: 20, max: 100)
@@ -220,11 +220,11 @@ Get the status of a transaction by its normalized hash to know if it is pending,
 `build_ton_transfer`, `build_jetton_transfer`, and `build_nft_transfer` do **not** broadcast. They build a transaction and return ready-to-send `messages` (the `transaction` field). Preview them with `emulate_transaction`, then broadcast with `send_raw_transaction` — the same pipeline used by `get_swap_quote`. Only `send_raw_transaction` signs and sends. When broadcasting, pass the returned `transaction.fromAddress` along with the messages: jetton and NFT transfers are bound to the wallet they were built for.
 
 #### `build_ton_transfer`
-Build a TON transfer to an address. Amount is in human-readable format (e.g., `"1.5"` means 1.5 TON). Returns `transaction: { messages, validUntil, fromAddress }`. Preview with `emulate_transaction`, then broadcast with `send_raw_transaction`.
+Build a GRAM (ex. TON) transfer to an address. Amount is in human-readable format (e.g., `"1.5"` means 1.5 GRAM). Returns `transaction: { messages, validUntil, fromAddress }`. Preview with `emulate_transaction`, then broadcast with `send_raw_transaction`.
 
 **Parameters:**
 - `toAddress` (required): Recipient TON address
-- `amount` (required): Amount in TON (e.g., `"1.5"`)
+- `amount` (required): Amount in GRAM (ex. TON) (e.g., `"1.5"`)
 - `comment` (optional): Transaction comment/memo
 
 #### `build_jetton_transfer`
@@ -249,7 +249,7 @@ Sign and broadcast a raw transaction with full control over messages. Supports m
 - `fromAddress` (optional): Sender wallet address; when broadcasting a prepared transaction, pass its `transaction.fromAddress`
 
 #### `emulate_transaction`
-Dry-run a raw transaction without broadcasting it. Accepts the same `messages` format as `send_raw_transaction` and returns the expected TON and Jetton balance changes, fees, and high-level actions so agents can verify a transaction before sending.
+Dry-run a raw transaction without broadcasting it. Accepts the same `messages` format as `send_raw_transaction` and returns the expected GRAM (ex. TON) and Jetton balance changes, fees, and high-level actions so agents can verify a transaction before sending.
 
 **Parameters:**
 - `messages` (required): Array of messages, each with `address`, `amount` in nanotons, and optional `stateInit` / `payload`
@@ -261,9 +261,9 @@ Dry-run a raw transaction without broadcasting it. Accepts the same `messages` f
 Get a quote for swapping tokens. Returns quote details and transaction params that can be executed via `send_raw_transaction`.
 
 **Parameters:**
-- `fromToken` (required): Token to swap from (`"TON"` or jetton address)
-- `toToken` (required): Token to swap to (`"TON"` or jetton address)
-- `amount` (required): Amount in human-readable format (e.g., `"1.5"` for 1.5 TON)
+- `fromToken` (required): Token to swap from (`"TON"` for native GRAM (ex. TON), or jetton address)
+- `toToken` (required): Token to swap to (`"TON"` for native GRAM (ex. TON), or jetton address)
+- `amount` (required): Amount in human-readable format (e.g., `"1.5"` for 1.5 GRAM (ex. TON))
 - `slippageBps` (optional): Slippage tolerance in basis points (default: 100 = 1%)
 
 ### NFTs
@@ -361,7 +361,7 @@ Start first-root-agent setup: generate operator keys, persist a pending draft, a
 - `name` (optional): Agent display name
 - `source` (optional): Source or description
 - `collectionAddress` (optional): Collection address override
-- `tonDeposit` (optional): TON deposit hint for the dashboard
+- `tonDeposit` (optional): GRAM (ex. TON) deposit hint for the dashboard
 
 Pending onboarding callback state is persisted in the local config, so the setup can be resumed after MCP transport restarts. In HTTP mode, callback URLs are stable on the MCP server base URL. In stdio mode, use `AGENTIC_CALLBACK_BASE_URL` and/or `AGENTIC_CALLBACK_PORT` if you need a fixed callback endpoint across restarts.
 

--- a/packages/mcp/USAGE_EXAMPLES.md
+++ b/packages/mcp/USAGE_EXAMPLES.md
@@ -118,7 +118,7 @@ npx @ton/mcp@alpha get_current_wallet
 
 **User request**
 
-`Show my balance in TON and jettons`
+`Show my balance in GRAM (ex. TON) and jettons`
 
 **Approximate command list**
 
@@ -129,7 +129,7 @@ npx @ton/mcp@alpha get_jettons
 
 **Approximate agent response**
 
-> Active wallet balance: `12.84 TON`. Jetton balances include `USDT 53.2`, `NOT 1400`, and `STON 18.05`.
+> Active wallet balance: `12.84 GRAM (ex. TON)`. Jetton balances include `USDT 53.2`, `NOT 1400`, and `STON 18.05`.
 
 ### Show the balance of any address
 
@@ -146,7 +146,7 @@ npx @ton/mcp@alpha get_jettons_by_address --address EQ...
 
 **Approximate agent response**
 
-> Address `EQ...` has a balance of `3.21 TON`. No jettons were found for that address.
+> Address `EQ...` has a balance of `3.21 GRAM (ex. TON)`. No jettons were found for that address.
 
 ### Find a known jetton address
 
@@ -184,11 +184,11 @@ npx @ton/mcp@alpha generate_ton_proof --domain getgems.io --payload getgems-llm
 
 ## Transfers and Swaps
 
-### Send TON to a TON DNS name
+### Send GRAM (ex. TON) to a TON DNS name
 
 **User request**
 
-`Send 1 TON to foundation.ton`
+`Send 1 GRAM (ex. TON) to foundation.ton`
 
 **Approximate command list**
 
@@ -202,13 +202,13 @@ npx @ton/mcp@alpha get_transaction_status --normalizedHash <NORMALIZED_HASH>
 
 **Approximate agent response**
 
-> `foundation.ton` was resolved to TON address `EQ...`. The `1 TON` transfer was sent with `normalizedHash: <NORMALIZED_HASH>`. Transaction status: `completed`.
+> `foundation.ton` was resolved to TON address `EQ...`. The `1 GRAM (ex. TON)` transfer was sent with `normalizedHash: <NORMALIZED_HASH>`. Transaction status: `completed`.
 
-### Preview a TON transfer before sending
+### Preview a GRAM (ex. TON) transfer before sending
 
 **User request**
 
-`Prepare a 0.5 TON payment to UQAbc... and show me what happens before sending`
+`Prepare a 0.5 GRAM (ex. TON) payment to UQAbc... and show me what happens before sending`
 
 **Approximate command list**
 
@@ -219,7 +219,7 @@ npx @ton/mcp@alpha emulate_transaction --messages '<transaction.messages>'
 
 **Approximate agent response**
 
-> Prepared the `0.5 TON` transfer (it was not sent). Emulation shows the expected balance changes and fees. Confirm to broadcast it with `send_raw_transaction`.
+> Prepared the `0.5 GRAM (ex. TON)` transfer (it was not sent). Emulation shows the expected balance changes and fees. Confirm to broadcast it with `send_raw_transaction`.
 
 ### Send a jetton
 
@@ -241,11 +241,11 @@ npx @ton/mcp@alpha get_transaction_status --normalizedHash <NORMALIZED_HASH>
 
 > `USDT` was found in the wallet. I prepared the `25 USDT` transfer to `UQAbc...`, previewed it, then broadcast it with `send_raw_transaction`. `normalizedHash: <NORMALIZED_HASH>`. Current status: `completed`.
 
-### Swap TON for a jetton
+### Swap GRAM (ex. TON) for a jetton
 
 **User request**
 
-`Swap 2 TON to USDT`
+`Swap 2 GRAM (ex. TON) to USDT`
 
 **Approximate command list**
 
@@ -261,7 +261,7 @@ npx @ton/mcp@alpha get_transaction_status --normalizedHash <NORMALIZED_HASH>
 
 **Approximate agent response**
 
-> A quote was received for swapping `2 TON` to `USDT`. After confirmation, the swap was executed with an expected output of about `X USDT` after slippage. `normalizedHash: <NORMALIZED_HASH>`.
+> A quote was received for swapping `2 GRAM (ex. TON)` to `USDT`. After confirmation, the swap was executed with an expected output of about `X USDT` after slippage. `normalizedHash: <NORMALIZED_HASH>`.
 
 ### Show recent transactions
 
@@ -277,7 +277,7 @@ npx @ton/mcp@alpha get_transactions --limit 5
 
 **Approximate agent response**
 
-> The last 5 operations were shown, including incoming and outgoing TON transfers, jetton transfers, and swaps. For each transaction, the agent typically shows the time, action type, amount, and final status.
+> The last 5 operations were shown, including incoming and outgoing GRAM (ex. TON) transfers, jetton transfers, and swaps. For each transaction, the agent typically shows the time, action type, amount, and final status.
 
 ## TON DNS
 

--- a/packages/mcp/llms.txt
+++ b/packages/mcp/llms.txt
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This MCP server provides tools for managing TON blockchain wallets. It supports wallet info, balance queries, transfers (TON, Jettons, NFTs), token swaps, transaction history, DNS resolution, TonProof authentication, local multi-wallet registry management, and agentic wallet onboarding.
+This MCP server provides tools for managing TON blockchain wallets. It supports wallet info, balance queries, transfers (GRAM (ex. TON), Jettons, NFTs), token swaps, transaction history, DNS resolution, TonProof authentication, local multi-wallet registry management, and agentic wallet onboarding.
 
 It has two runtime modes:
 - Registry mode: if `MNEMONIC` and `PRIVATE_KEY` are not set, wallets are loaded from the local TON config registry (`~/.config/ton/config.json` or `TON_CONFIG_PATH`)
@@ -38,14 +38,14 @@ Parameters:
 - walletSelector (required): wallet id, name, or address
 
 ### get_balance
-Get TON balance of the wallet.
-Returns: address, balance in TON and nanoTON
+Get GRAM (ex. TON) balance of the wallet.
+Returns: address, balance in GRAM (ex. TON) and nanoTON
 
 ### get_balance_by_address
-Get TON balance for any address.
+Get GRAM (ex. TON) balance for any address.
 Parameters:
 - address (required): TON wallet address
-Returns: address, balance in TON and nanoTON
+Returns: address, balance in GRAM (ex. TON) and nanoTON
 
 ### get_jetton_balance
 Get balance of a specific Jetton token.
@@ -87,10 +87,10 @@ Get list of known/popular Jettons on TON.
 Returns: array with symbol, name, address, decimals
 
 ### build_ton_transfer
-Build a TON transfer to an address. Does NOT broadcast.
+Build a GRAM (ex. TON) transfer to an address. Does NOT broadcast.
 Parameters:
 - toAddress (required): recipient address
-- amount (required): amount in TON (e.g., "1.5")
+- amount (required): amount in GRAM (ex. TON) (e.g., "1.5")
 - comment (optional): transaction memo
 Returns: transaction {messages, validUntil, fromAddress} ready for emulate_transaction (preview) then send_raw_transaction (broadcast)
 
@@ -116,14 +116,14 @@ Dry-run a raw transaction without broadcasting it.
 Parameters:
 - messages (required): array of {address, amount (nanoTON), stateInit?, payload?}
 - validUntil (optional): expiry timestamp
-Returns: expected TON and Jetton balance changes, fees, and high-level actions
+Returns: expected GRAM (ex. TON) and Jetton balance changes, fees, and high-level actions
 
 ### get_swap_quote
 Get quote for token swap.
 Parameters:
-- fromToken (required): "TON" or jetton address
-- toToken (required): "TON" or jetton address
-- amount (required): human-readable amount (e.g., "1.5" for 1.5 TON)
+- fromToken (required): "TON" (native GRAM (ex. TON)) or jetton address
+- toToken (required): "TON" (native GRAM (ex. TON)) or jetton address
+- amount (required): human-readable amount (e.g., "1.5" for 1.5 GRAM (ex. TON))
 - slippageBps (optional): slippage in basis points (100 = 1%)
 Returns: quote details + transaction params for send_raw_transaction
 
@@ -219,7 +219,7 @@ Parameters:
 - name (optional): display name
 - source (optional): source or description
 - collectionAddress (optional): collection override
-- tonDeposit (optional): TON deposit hint
+- tonDeposit (optional): GRAM (ex. TON) deposit hint
 
 ### agentic_list_pending_root_wallet_setups
 Registry mode only. List pending root-agent onboarding drafts.
@@ -249,7 +249,7 @@ Parameters:
 3. set_active_wallet if the user wants to switch
 4. For one-off calls, pass walletSelector directly to wallet-scoped tools instead of changing the active wallet
 
-### Sending TON
+### Sending GRAM (ex. TON)
 1. If recipient is a DNS name rather than a raw address: resolve_dns first
 2. build_ton_transfer with resolved address (builds only — does NOT broadcast)
 3. emulate_transaction with the returned transaction.messages to preview balance changes and fees (recommended before sending)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ton/mcp",
-  "version": "0.1.15-alpha.22",
+  "version": "0.1.15-alpha.23",
   "description": "TON MCP Server - Model Context Protocol server for TON blockchain wallet operations",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp/skills/ton-balance/SKILL.md
+++ b/packages/mcp/skills/ton-balance/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ton-balance
-description: Check TON wallet balances, token holdings, and transaction history. Use when the user wants to check their balance, see how much TON they have, list tokens, view jettons, check transaction history, look up a token, or verify a transaction status.
+description: Check TON wallet balances, token holdings, and transaction history. Use when the user wants to check their balance, see how much GRAM (ex. TON) they have, list tokens, view jettons, check transaction history, look up a token, or verify a transaction status.
 user-invocable: true
 disable-model-invocation: false
 ---
 
-# TON Balance & Transaction Queries
+# GRAM (ex. TON) Balance & Transaction Queries
 
 Read-only queries for wallet balances, token holdings, and transaction history on TON.
 
@@ -28,7 +28,7 @@ Read-only queries for wallet balances, token holdings, and transaction history o
 
 ### Check Balance
 1. Call `get_wallet` for address and network info
-2. Call `get_balance` for TON balance
+2. Call `get_balance` for GRAM (ex. TON) balance
 3. Call `get_jettons` for all token holdings
 
 ### Check Specific Token
@@ -45,4 +45,4 @@ Read-only queries for wallet balances, token holdings, and transaction history o
 
 - All tools are read-only — no confirmation needed
 - In registry mode, pass `walletSelector` to query a specific wallet instead of the active one
-- All balance responses include both `amountRaw` (raw integer string) and `amount` (human-readable decimal string, e.g. `"1.5"` for 1.5 TON). Use `amount` for display; use `amountRaw` only when a raw integer is required.
+- All balance responses include both `amountRaw` (raw integer string) and `amount` (human-readable decimal string, e.g. `"1.5"` for 1.5 GRAM (ex. TON)). Use `amount` for display; use `amountRaw` only when a raw integer is required.

--- a/packages/mcp/skills/ton-cli/SKILL.md
+++ b/packages/mcp/skills/ton-cli/SKILL.md
@@ -134,7 +134,7 @@ Without `MNEMONIC` or `PRIVATE_KEY`, the CLI uses the local config registry at `
 # Check wallet address and network
 npx @ton/mcp@alpha get_wallet
 
-# Check TON balance
+# Check GRAM (ex. TON) balance
 npx @ton/mcp@alpha get_balance
 
 # List all tokens
@@ -155,7 +155,7 @@ npx @ton/mcp@alpha get_balance --walletSelector "my-hot-wallet"
 # In registry mode: list all registered wallets
 npx @ton/mcp@alpha list_wallets
 
-# Send TON — build, preview, then broadcast (confirm with user before the broadcast step)
+# Send GRAM (ex. TON) — build, preview, then broadcast (confirm with user before the broadcast step)
 npx @ton/mcp@alpha build_ton_transfer --toAddress UQA... --amount 0.5 --comment "payment"
 npx @ton/mcp@alpha emulate_transaction --messages '<transaction.messages>'        # recommended preview
 npx @ton/mcp@alpha send_raw_transaction --messages '<transaction.messages>' --fromAddress '<transaction.fromAddress>'

--- a/packages/mcp/skills/ton-create-wallet/SKILL.md
+++ b/packages/mcp/skills/ton-create-wallet/SKILL.md
@@ -57,4 +57,4 @@ Deploy an on-chain agentic wallet on TON. The agent generates operator keys, ope
 - Callback-driven completion is for long-lived stdio/HTTP MCP server sessions; raw CLI should use manual `walletAddress` completion
 - If automatic dashboard opening is supported in the current environment, do it instead of asking the user to open the URL manually
 - In raw CLI mode, ask for the wallet address after deployment because the callback server is not available long enough to complete the flow
-- After wallet creation, fund the wallet with TON before using transfer or swap skills
+- After wallet creation, fund the wallet with GRAM (ex. TON) before using transfer or swap skills

--- a/packages/mcp/skills/ton-send/SKILL.md
+++ b/packages/mcp/skills/ton-send/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ton-send
-description: Send TON or jettons (tokens) to an address or TON DNS domain. Use when the user wants to send TON, transfer tokens, send jettons, pay someone, send funds to a .ton or .t.me domain, or transfer assets on the TON blockchain.
+description: Send GRAM (ex. TON) or jettons (tokens) to an address or TON DNS domain. Use when the user wants to send GRAM (ex. TON), transfer tokens, send jettons, pay someone, send funds to a .ton or .t.me domain, or transfer assets on the TON blockchain.
 user-invocable: true
 disable-model-invocation: false
 ---
 
-# Send TON & Tokens
+# Send GRAM (ex. TON) & Tokens
 
-Transfer TON or jettons to any address. Supports TON DNS resolution for `.ton` and `.t.me` domains.
+Transfer GRAM (ex. TON) or jettons to any address. Supports TON DNS resolution for `.ton` and `.t.me` domains.
 
 ## MCP Tools
 
@@ -24,7 +24,7 @@ Transfer TON or jettons to any address. Supports TON DNS resolution for `.ton` a
 
 ## Workflows
 
-### Send TON
+### Send GRAM (ex. TON)
 1. If the user provides a DNS name (e.g., `foundation.ton`, `user.t.me`) instead of a raw address, call `resolve_dns` first
 2. Call `build_ton_transfer` with address and amount to build the transaction (it is NOT sent)
 3. Preview it with `emulate_transaction` using the returned `transaction.messages` (recommended before broadcasting)
@@ -43,7 +43,7 @@ Transfer TON or jettons to any address. Supports TON DNS resolution for `.ton` a
 
 ## Notes
 
-- Amounts are human-readable (e.g., `"1.5"` = 1.5 TON, `"100"` = 100 tokens)
+- Amounts are human-readable (e.g., `"1.5"` = 1.5 GRAM (ex. TON), `"100"` = 100 tokens)
 - `build_ton_transfer`/`build_jetton_transfer` build the transaction only; `send_raw_transaction` is the tool that actually signs and broadcasts
 - Use `emulate_transaction` to preview expected balance changes before broadcasting (fake signature)
 - Always confirm with the user before broadcasting a transfer; prefer the host client's structured confirmation UI when available, otherwise accept natural-language yes/no and do not require a fixed confirmation phrase

--- a/packages/mcp/skills/ton-swap/SKILL.md
+++ b/packages/mcp/skills/ton-swap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ton-swap
-description: Swap or trade tokens on the TON blockchain via DEX. Use when the user wants to swap, trade, exchange, convert, buy, or sell tokens like TON, USDT, jUSDC, or any jetton. Covers phrases like "swap TON for USDT", "trade tokens", "buy USDT", "exchange jettons".
+description: Swap or trade tokens on the TON blockchain via DEX. Use when the user wants to swap, trade, exchange, convert, buy, or sell tokens like GRAM (ex. TON), USDT, jUSDC, or any jetton. Covers phrases like "swap GRAM (ex. TON) for USDT", "trade tokens", "buy USDT", "exchange jettons".
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -22,9 +22,9 @@ Swap tokens on TON via DEX aggregator. Two-step flow: get a quote, confirm with 
 
 1. If the user mentions a token by name (e.g., "USDT", "jUSDC"), call `get_known_jettons` to resolve the jetton address
 2. Call `get_swap_quote` with `fromToken`, `toToken`, and `amount`
-   - Use `"TON"` for native TON, or the jetton master contract address for tokens
-   - Amount is human-readable (e.g., `"1.5"` = 1.5 TON)
-3. Call `emulate_transaction` with the quote's `transaction.messages` to dry-run the swap — verify the expected money flow (TON/jetton balance changes) before sending
+   - Use `"TON"` for native GRAM (ex. TON), or the jetton master contract address for tokens
+   - Amount is human-readable (e.g., `"1.5"` = 1.5 GRAM (ex. TON))
+3. Call `emulate_transaction` with the quote's `transaction.messages` to dry-run the swap — verify the expected money flow (GRAM (ex. TON)/jetton balance changes) before sending
 4. Show the quote details and emulation results to the user and ask one short yes/no confirmation
 5. Call `send_raw_transaction` with the transaction params returned by the quote
 6. Poll `get_transaction_status` with the returned `normalizedHash` until status is `completed` or `failed` (see `ton-balance` skill). User can ask to skip polling.

--- a/packages/mcp/skills/ton-xstocks/SKILL.md
+++ b/packages/mcp/skills/ton-xstocks/SKILL.md
@@ -10,7 +10,7 @@ disable-model-invocation: false
 Backed **xStocks** are jettons on TON. Resolve the **jetton master** from the public xStocks API, then use the same **quote → execute** flow as `ton-swap`, with routing preferences learned from real Omniston behavior.
 
 > **Critical: USDT is the only working swap pair.**  
-> Omniston consistently returns **no quote** for TON → xStock and xStock → TON routes.  
+> Omniston consistently returns **no quote** for GRAM (ex. TON) → xStock and xStock → GRAM routes.  
 > All xStock buys and sells **must** go through USDT. If the user lacks sufficient USDT, buy USDT with TON first (see §Pre-fund USDT below).
 
 ## Key addresses
@@ -37,7 +37,7 @@ Backed **xStocks** are jettons on TON. Resolve the **jetton master** from the pu
 
 | Action | Tools |
 | ------ | ----- |
-| Pre-fund USDT | `get_jetton_balance` (USDT) → `get_swap_quote` (TON → USDT) → `emulate_transaction` → `send_raw_transaction` |
+| Pre-fund USDT | `get_jetton_balance` (USDT) → `get_swap_quote` (GRAM (ex. TON) → USDT) → `emulate_transaction` → `send_raw_transaction` |
 | Buy xStock | `get_swap_quote` (USDT → xStock) → `emulate_transaction` → `send_raw_transaction` |
 | Sell xStock | `get_jetton_balance` (xStock) → `get_swap_quote` (xStock → USDT) → `emulate_transaction` → `send_raw_transaction` |
 | Verify | `get_jetton_info`, `get_transaction_status`, `get_jetton_balance` |
@@ -50,7 +50,7 @@ Amounts for `get_swap_quote` are **human-readable** strings (respect jetton deci
 | ---- | --- | -------- |
 | `get_jetton_info` | jettonAddress | `--jettonAddress` |
 | `get_jetton_balance` | jettonAddress | `--jettonAddress` |
-| `get_swap_quote` | fromToken | `--fromToken` (use `"TON"` for native TON, jetton master address for tokens) |
+| `get_swap_quote` | fromToken | `--fromToken` (use `"TON"` for native GRAM (ex. TON), jetton master address for tokens) |
 | `get_swap_quote` | toToken | `--toToken` |
 | `get_swap_quote` | amount | `--amount` (human-readable) |
 | `get_swap_quote` | slippageBps | `--slippageBps` (default 100 = 1%) |
@@ -66,7 +66,7 @@ Before any xStock trade, check the user's USDT balance:
 2. If `amount` **< required amount** for the planned buy:
    a. Calculate the shortfall (include a small buffer for price movement).
    b. `get_swap_quote` with `fromToken` = `"TON"` (the literal string, not an address), `toToken` = USDT master, `amount` = shortfall.
-   c. Confirm with the user: *"You need ~X USDT but only have Y. Swap Z TON → X USDT first?"*
+   c. Confirm with the user: *"You need ~X USDT but only have Y. Swap Z GRAM (ex. TON) → X USDT first?"*
    d. On approval, `send_raw_transaction` → poll `get_transaction_status` until `completed`.
    e. Re-check USDT balance before proceeding to the xStock buy.
 
@@ -76,11 +76,11 @@ Before any xStock trade, check the user's USDT balance:
 2. Check USDT balance — run **Pre-fund USDT** if insufficient.
 3. `get_swap_quote`: `fromToken` = USDT master, `toToken` = xStock master, `amount` = USDT to spend, `slippageBps` = 100 (1 %).
 4. `emulate_transaction` with the quote's `transaction.messages` — verify expected balance changes before sending.
-5. Show the user: **fromAmount**, **toAmount**, **minReceived**, **expiresAt**, emulation results, and note the forward **TON** on router messages (gas).
+5. Show the user: **fromAmount**, **toAmount**, **minReceived**, **expiresAt**, emulation results, and note the forward **GRAM (ex. TON)** on router messages (gas).
 6. Confirm once, then `send_raw_transaction` with the returned `transaction.messages`.
 7. Poll `get_transaction_status` on `normalizedHash` until `completed` or `failed`.
 
-> **Do not attempt TON → xStock directly.** It will return no quote. Always route through USDT.
+> **Do not attempt GRAM (ex. TON) → xStock directly.** It will return no quote. Always route through USDT.
 
 ## Sell workflow ("sell all" or fixed amount)
 
@@ -91,7 +91,7 @@ Before any xStock trade, check the user's USDT balance:
 5. Show the user the quote details and emulation results, then confirm.
 6. `send_raw_transaction`, then poll `get_transaction_status` until `completed` or `failed`.
 
-> **Do not attempt xStock → TON directly.** Always sell into USDT.
+> **Do not attempt xStock → GRAM (ex. TON) directly.** Always sell into USDT.
 
 ## Post-trade checks
 
@@ -100,7 +100,7 @@ Before any xStock trade, check the user's USDT balance:
 
 ## Omniston quirks
 
-- **"No quote available"** — no route at that size / time. Retry after a short wait, or adjust amount / slippage slightly. Do **not** switch to TON pairing; it won't help.
+- **"No quote available"** — no route at that size / time. Retry after a short wait, or adjust amount / slippage slightly. Do **not** switch to GRAM (ex. TON) pairing; it won't help.
 - Occasional WebSocket errors (e.g. quote ack) — **retry** `get_swap_quote`.
 - Quotes **expire**; if the user waited before confirming, fetch a fresh quote before executing.
 

--- a/packages/mcp/src/services/McpWalletService.ts
+++ b/packages/mcp/src/services/McpWalletService.ts
@@ -122,7 +122,7 @@ export interface TransactionInfo {
         | 'SmartContractExec'
         | 'Unknown';
     status: 'success' | 'failure';
-    // For GRAM transfers
+    // For GRAM (ex. TON) transfers
     from?: string;
     to?: string;
     amount?: string;
@@ -492,14 +492,14 @@ export class McpWalletService {
     }
 
     /**
-     * Get GRAM balance
+     * Get GRAM (ex. TON) balance
      */
     async getBalance(): Promise<string> {
         return this.wallet.getBalance();
     }
 
     /**
-     * Get GRAM balance for any address.
+     * Get GRAM (ex. TON) balance for any address.
      */
     async getBalanceByAddress(address: string): Promise<AddressBalanceResult> {
         const normalizedAddress = Address.parse(address).toString();
@@ -894,9 +894,9 @@ export class McpWalletService {
 
     /**
      * Get swap quote with transaction params ready to execute
-     * @param fromToken Token to swap from ("TON" or jetton address)
-     * @param toToken Token to swap to ("TON" or jetton address)
-     * @param amount Amount to swap in human-readable format (e.g., "1.5" for 1.5 GRAM)
+     * @param fromToken Token to swap from ("TON" for native GRAM (ex. TON), or jetton address)
+     * @param toToken Token to swap to ("TON" for native GRAM (ex. TON), or jetton address)
+     * @param amount Amount to swap in human-readable format (e.g., "1.5" for 1.5 GRAM (ex. TON))
      * @param slippageBps Slippage tolerance in basis points (default 100 = 1%)
      */
     async getSwapQuote(
@@ -908,7 +908,7 @@ export class McpWalletService {
         const network = this.wallet.getNetwork();
         const kit = await this.getKit();
 
-        // Get decimals for tokens (GRAM has 9 decimals, jettons need to be fetched)
+        // Get decimals for tokens (GRAM (ex. TON) has 9 decimals, jettons need to be fetched)
         const getDecimals = async (token: string): Promise<number> => {
             if (token === 'TON' || token === 'ton') {
                 return 9;

--- a/packages/mcp/src/tools/address-tools.ts
+++ b/packages/mcp/src/tools/address-tools.ts
@@ -46,7 +46,7 @@ export function createMcpAddressTools(service: McpWalletService) {
     return {
         get_balance_by_address: {
             description:
-                'Get GRAM balance for any wallet address. Returns both human-readable and raw (nano units) values.',
+                'Get GRAM (ex. TON) balance for any wallet address. Returns both human-readable and raw (nano units) values.',
             inputSchema: getBalanceByAddressSchema,
             handler: async (args: z.infer<typeof getBalanceByAddressSchema>): Promise<ToolResponse> => {
                 try {

--- a/packages/mcp/src/tools/agentic-onboarding-tools.ts
+++ b/packages/mcp/src/tools/agentic-onboarding-tools.ts
@@ -52,7 +52,7 @@ const startAgenticRootWalletSetupSchema = z.object({
     name: z.string().optional().describe('Optional agent display name'),
     source: z.string().optional().describe('Optional source / description'),
     collectionAddress: z.string().optional().describe('Optional collection address override'),
-    tonDeposit: z.string().optional().describe('Optional GRAM deposit hint for the dashboard'),
+    tonDeposit: z.string().optional().describe('Optional GRAM (ex. TON) deposit hint for the dashboard'),
 });
 
 const setupIdSchema = z.object({

--- a/packages/mcp/src/tools/agentic-tools.ts
+++ b/packages/mcp/src/tools/agentic-tools.ts
@@ -26,7 +26,10 @@ export const deployAgenticSubwalletSchema = z.object({
         .min(1)
         .describe('Public key for the new sub-wallet operator (uint256, decimal or 0x-prefixed hex).'),
     metadata: agenticMetadataSchema.describe('Required onchain NFT metadata (TEP-64). Must include at least `name`.'),
-    amountTon: z.string().optional().describe('GRAM (ex. TON) amount to attach for deployment in GRAM units (default: "0.05").'),
+    amountTon: z
+        .string()
+        .optional()
+        .describe('GRAM (ex. TON) amount to attach for deployment in GRAM units (default: "0.05").'),
 });
 
 export function createMcpAgenticTools(service: McpWalletService) {

--- a/packages/mcp/src/tools/agentic-tools.ts
+++ b/packages/mcp/src/tools/agentic-tools.ts
@@ -26,7 +26,7 @@ export const deployAgenticSubwalletSchema = z.object({
         .min(1)
         .describe('Public key for the new sub-wallet operator (uint256, decimal or 0x-prefixed hex).'),
     metadata: agenticMetadataSchema.describe('Required onchain NFT metadata (TEP-64). Must include at least `name`.'),
-    amountTon: z.string().optional().describe('GRAM amount to attach for deployment in GRAM units (default: "0.05").'),
+    amountTon: z.string().optional().describe('GRAM (ex. TON) amount to attach for deployment in GRAM units (default: "0.05").'),
 });
 
 export function createMcpAgenticTools(service: McpWalletService) {
@@ -39,7 +39,7 @@ export function createMcpAgenticTools(service: McpWalletService) {
                 try {
                     const amountTon = args.amountTon ?? '0.05';
                     if (!TON_AMOUNT_REGEX.test(amountTon)) {
-                        throw new Error('amountTon must be a positive GRAM value with up to 9 decimals');
+                        throw new Error('amountTon must be a positive GRAM (ex. TON) value with up to 9 decimals');
                     }
 
                     const result = await service.deployAgenticSubwallet({

--- a/packages/mcp/src/tools/balance-tools.ts
+++ b/packages/mcp/src/tools/balance-tools.ts
@@ -58,7 +58,7 @@ export function createMcpBalanceTools(service: McpWalletService) {
 
         get_balance: {
             description:
-                'Get the GRAM balance of the wallet. Returns both human-readable and raw (nano units) amounts.',
+                'Get the GRAM (ex. TON) balance of the wallet. Returns both human-readable and raw (nano units) amounts.',
             inputSchema: getBalanceSchema,
             handler: async (): Promise<ToolResponse> => {
                 try {
@@ -192,7 +192,7 @@ export function createMcpBalanceTools(service: McpWalletService) {
 
         get_transactions: {
             description:
-                'Get recent transaction history for the wallet. Returns events with actions like GRAM transfers, Jetton transfers, swaps, and more.',
+                'Get recent transaction history for the wallet. Returns events with actions like GRAM (ex. TON) transfers, Jetton transfers, swaps, and more.',
             inputSchema: getTransactionsSchema,
             handler: async (args: z.infer<typeof getTransactionsSchema>): Promise<ToolResponse> => {
                 try {
@@ -213,7 +213,7 @@ export function createMcpBalanceTools(service: McpWalletService) {
                                             status: tx.status,
                                             description: tx.description,
                                             isScam: tx.isScam,
-                                            // GRAM transfer details
+                                            // GRAM (ex. TON) transfer details
                                             ...(tx.type === 'TonTransfer' && {
                                                 from: tx.from,
                                                 to: tx.to,

--- a/packages/mcp/src/tools/swap-tools.ts
+++ b/packages/mcp/src/tools/swap-tools.ts
@@ -12,9 +12,9 @@ import type { McpWalletService } from '../services/McpWalletService.js';
 import type { ToolResponse } from './types.js';
 
 export const getSwapQuoteSchema = z.object({
-    fromToken: z.string().min(1).describe('Token to swap from ("TON" or jetton address)'),
-    toToken: z.string().min(1).describe('Token to swap to ("TON" or jetton address)'),
-    amount: z.string().min(1).describe('Amount to swap in human-readable format (e.g., "1.5" for 1.5 GRAM)'),
+    fromToken: z.string().min(1).describe('Token to swap from ("TON" for native GRAM (ex. TON), or a jetton address)'),
+    toToken: z.string().min(1).describe('Token to swap to ("TON" for native GRAM (ex. TON), or a jetton address)'),
+    amount: z.string().min(1).describe('Amount to swap in human-readable format (e.g., "1.5" for 1.5 GRAM (ex. TON))'),
     slippageBps: z.number().optional().describe('Slippage tolerance in basis points (default 100 = 1%)'),
 });
 

--- a/packages/mcp/src/tools/transfer-tools.ts
+++ b/packages/mcp/src/tools/transfer-tools.ts
@@ -14,7 +14,7 @@ import type { ToolResponse } from './types.js';
 
 export const tonTransferSchema = z.object({
     toAddress: z.string().min(1).describe('Recipient TON address'),
-    amount: z.string().min(1).describe('Amount of GRAM to send (e.g., "1.5" for 1.5 GRAM)'),
+    amount: z.string().min(1).describe('Amount of GRAM (ex. TON) to send (e.g., "1.5" for 1.5 GRAM)'),
     comment: z.string().optional().describe('Optional comment/memo for the transaction'),
 });
 
@@ -77,7 +77,7 @@ export function createMcpTransferTools(service: McpWalletService) {
     return {
         build_ton_transfer: {
             description:
-                'Prepare a GRAM transfer from the wallet to an address. Amount is in GRAM (e.g., "1.5" means 1.5 GRAM). Does NOT broadcast: returns ready-to-send transaction messages. Preview them with emulate_transaction, then broadcast with send_raw_transaction.',
+                'Prepare a GRAM (ex. TON) transfer from the wallet to an address. Amount is in GRAM (e.g., "1.5" means 1.5 GRAM). Does NOT broadcast: returns ready-to-send transaction messages. Preview them with emulate_transaction, then broadcast with send_raw_transaction.',
             inputSchema: tonTransferSchema,
             handler: async (args: z.infer<typeof tonTransferSchema>): Promise<ToolResponse> => {
                 try {
@@ -216,7 +216,7 @@ export function createMcpTransferTools(service: McpWalletService) {
         },
         emulate_transaction: {
             description:
-                'Emulate a transaction without broadcasting it. Dry-run that returns the expected money flow (GRAM and jetton balance changes) so you can verify a transaction before sending. Accepts the same messages format as send_raw_transaction.',
+                'Emulate a transaction without broadcasting it. Dry-run that returns the expected money flow (GRAM (ex. TON) and jetton balance changes) so you can verify a transaction before sending. Accepts the same messages format as send_raw_transaction.',
             inputSchema: emulateTransactionSchema,
             handler: async (args: z.infer<typeof emulateTransactionSchema>): Promise<ToolResponse> => {
                 try {


### PR DESCRIPTION
## What & why

Toncoin (ticker **TON**) was renamed to **GRAM**. This aligns `packages/mcp` with the rename by annotating every user-facing reference to the **coin** as **"GRAM (ex. TON)"**, while leaving all **TON Blockchain / network / protocol** references untouched.

## Scope

**Renamed → "GRAM (ex. TON)"** (the asset): balances, amounts, transfers, sends, swaps, deposits, gas, swap-pair routes, `1.5 TON` → `1.5 GRAM`.

**Kept as "TON"** (ecosystem / identifiers):
- Blockchain/protocol: `TON blockchain`, `TON network`, `TON DNS`, `TonProof` / `TonConnect`, `TON wallet/address`, "In TON, a transaction is complete when…".
- Config & providers: `~/.config/ton/config.json`, `TON_CONFIG_PATH`, Toncenter.
- **Code identifiers / API contract** (unchanged for backward compat): tool names (`build_ton_transfer`), types (`TonTransfer`), params (`amountTon`, `tonDeposit`), units (`nanoTon`), `TON_DECIMALS`, `@ton/walletkit`, and the literal `"TON"` swap selector.

First coin mention per string is annotated with `(ex. TON)`; immediate in-sentence repeats stay `GRAM` for readability. Runtime value labels (e.g. `` `${amount} GRAM` ``) unchanged.

## Files

- Tool descriptions & service JSDoc/comments: `src/tools/*.ts`, `src/services/McpWalletService.ts`
- Docs: `llms.txt`, `README.md`, `USAGE_EXAMPLES.md`
- Skills: `ton-balance`, `ton-send`, `ton-swap`, `ton-cli`, `ton-create-wallet`, `ton-xstocks`

## Versioning

- Bumped `@ton/mcp` `0.1.15-alpha.22` → `0.1.15-alpha.23`.
- Refreshed the existing shared `.changeset/rename-ton-to-gram.md` (`@ton/mcp` patch) to reflect the "GRAM (ex. TON)" wording — no new changeset added, to avoid a double mcp bump on the next `changeset version`.

## Verification

- `tsc --noEmit` — passes
- `vitest run` — **78/78 pass**
- No logic changed; edits are string/comment/doc text plus the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wallet, transfer, swap, and onboarding guidance to consistently use **GRAM (ex. TON)** for the native coin.
  * Clarified balance and transaction examples, including human-readable amounts and native-unit wording.
  * Added a note that only the coin name changed; blockchain/network references remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->